### PR TITLE
V1 of detail

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,33 @@
 detail
-########################################################################
+#######
+
+``detail`` allows contributors to create structured and configurable notes in a project,
+providing the ability to do automations such as:
+
+1. Ensuring that contributors add information to pull requests that provide
+   QA instructions, release notes, and associated tickets. The ``detail lint`` command
+   ensures that notes are present in a pull request and adhere to the schema.
+
+2. Rendering dynamic logs from the notes. ``detail log`` provides the ability
+   to slice and dice the commit log however you need, pulling in a ``notes``
+   variable in a Jinja template with all notes that can be grouped and filtered.
+
+3. Other automations, such as version bumping, Slack posting, ticket comments,
+   etc can be instrumented in continuous integration from the structured notes.
+
+When contributing a change, call ``detail`` to be prompted for all information
+defined in the project's detail schema. Information can be collected conditionally
+based on previous steps all thanks to the `formaldict <https://github.com/Opus10/formaldict>`__ library.
+
+Below is an example of a contributor creating a structured note with the type
+of change they are making, a summary, a description, and an associated Jira
+ticket:
+
+.. image:: https://raw.githubusercontent.com/opus10/detail/master/docs/_static/detail-intro.gif
+    :width: 600
+
+Notes are commited to projects, allowing review of them before they are used to
+perform automations in continuous integration.
 
 Documentation
 =============
@@ -20,3 +48,9 @@ Contributing Guide
 
 For information on setting up detail for development and
 contributing changes, view `CONTRIBUTING.rst <CONTRIBUTING.rst>`_.
+
+Primary Authors
+===============
+
+- @wesleykendall (Wes Kendall)
+- @tomage (Tómas Árni Jónasson)

--- a/detail/__init__.py
+++ b/detail/__init__.py
@@ -1,0 +1,22 @@
+from detail.core import Commit
+from detail.core import detail
+from detail.core import lint
+from detail.core import log
+from detail.core import Note
+from detail.core import NoteRange
+from detail.core import Notes
+from detail.core import Tag
+from detail.version import __version__
+
+
+__all__ = [
+    'Commit',
+    'Note',
+    'NoteRange',
+    'Notes',
+    'lint',
+    'log',
+    'detail',
+    'Tag',
+    '__version__',
+]

--- a/detail/cli.py
+++ b/detail/cli.py
@@ -1,0 +1,116 @@
+"""
+The detail CLI contains commands for creating notes, linting the
+notes, and rendering them.
+
+Commands
+~~~~~~~~
+
+* ``detail`` - Creates a note
+* ``detail log`` - Renders templated notes
+* ``detail lint`` - Validates structure of notes
+"""
+import sys
+
+import click
+from click_default_group import DefaultGroup
+
+import detail as detail_module
+from detail import core
+
+
+@click.group(cls=DefaultGroup, default='detail', default_if_no_args=True)
+def main():
+    pass
+
+
+@main.command()
+@click.argument('note', required=False)
+@click.option('-v', '--version', help='Show the version.', is_flag=True)
+def detail(note, version):
+    """
+    Create a new note or print the version of this library.
+
+    If a note path is provided, it will be updated.
+    """
+    if version:
+        click.echo(f'detail {detail_module.__version__}')
+    else:
+        note_path, _ = core.detail(path=note)
+        if note:
+            click.echo(f'Updated note at {note_path}')
+        else:
+            click.echo(f'Created note at {note_path}')
+
+
+@main.command()
+@click.argument('range', nargs=-1)
+@click.pass_context
+def lint(ctx, range):
+    """
+    Run note linting against a range of commits.
+
+    If ``:github/pr`` is provided as the range, the base branch of the pull
+    request will be used as the revision range (e.g. ``origin/develop..``).
+    """
+    range = ' '.join(range)
+    is_valid, notes = core.lint(range)
+
+    if not notes:
+        click.echo('No notes were found. Run "detail" to create one', err=True)
+        ctx.exit(1)
+
+    if not is_valid:
+        failures = notes.filter('is_valid', False)
+        err_msg = f'{len(failures)} out of {len(notes)} notes have failed linting:'
+        click.echo(click.style(err_msg, fg='red'), err=True)
+
+        for failure in failures:
+            click.echo(f'{failure.path}: {failure.validation_errors}', err=True)
+        ctx.exit(1)
+
+
+@main.command()
+@click.argument('range', nargs=-1)
+@click.option(
+    '--style',
+    default='default',
+    help=(
+        'A template file nickname to use. Defaults to .detail/log.tpl.'
+        ' When provided, .detail/log_{style}.tpl is loaded.'
+    ),
+)
+@click.option(
+    '--template', help='A template string to use. When provided, supercedes the "style" option.'
+)
+@click.option(
+    '--tag-match',
+    help=(
+        'A glob(7) pattern for matching tags when associating a tag with a'
+        ' note. Passed to ``git describe --contains --matches``'
+        ' when associating a tag with committed notes.'
+    ),
+)
+@click.option('--before', help='Filter notes before a date.')
+@click.option('--after', help='Filter notes after a date.')
+@click.option('--reverse', help='Reverse ordering of results.', is_flag=True)
+@click.option('-o', '--output', help='Output file name of the log.')
+def log(range, style, template, tag_match, before, after, reverse, output):
+    """
+    Run log output against a range of notes.
+
+    If ``:github/pr`` is provided as the range, the base branch of the pull
+    request will be used as the revision range (e.g. ``origin/develop..``).
+    If ``:github/pr`` is used as the output target, the log will be written
+    as a comment on the current Github pull request.
+    """
+    range = ' '.join(range)
+    core.log(
+        range,
+        style=style,
+        template=template,
+        tag_match=tag_match,
+        before=before,
+        after=after,
+        reverse=reverse,
+        output=output or sys.stdout,
+    )

--- a/detail/core.py
+++ b/detail/core.py
@@ -1,0 +1,629 @@
+"""
+The core detail API
+"""
+
+import collections.abc
+import datetime as dt
+import io
+import re
+import subprocess
+import uuid
+
+import dateutil.parser
+import formaldict
+import jinja2
+import yaml
+
+from detail import exceptions
+from detail import github
+from detail import utils
+
+
+# The default log Jinja template
+DEFAULT_LOG_TEMPLATE = """
+{% for tag, notes_by_tag in notes.group('commit_tag').items() %}
+## {{ tag|default('Unreleased', True) }} {% if tag.date %}({{ tag.date.date() }}){% endif %}
+{% for note in notes_by_tag %}
+- {{ note.commit_author_name }} [{{ note.commit_sha[:7] }}]
+
+{% for key, value in note.schema_data.items() %}
+  *{{ key }}*: {{ value|indent(4) }}
+{% endfor %}
+
+{% endfor %}
+{% endfor %}
+"""
+# The special range value for git ranges against github pull requests
+GITHUB_PR = ':github/pr'
+
+
+def _output(*, value, path):
+    """
+    Outputs a value to a path.
+
+    Args:
+        value (str): The string to output.
+        path (str|file): The path to which output is stored. If
+            given a string, the value will be stored to the path referenced
+            by the string. If ":github/pr" is the path, the value will be
+            written as a Github pull request comment. If the path is anything
+            but a string, it is treated as a file-like object. If path is
+            ``None``, nothing is written.
+    """
+    if isinstance(path, str) and path != GITHUB_PR:
+        with open(path, 'w+') as f:
+            f.write(value)
+    elif isinstance(path, str) and path == GITHUB_PR:
+        github.comment(value)
+    elif path is not None:
+        path.write(value)
+        path.flush()
+
+
+def _load_commit_schema(path=None, full=True):
+    """Loads the schema expected for parsed commit messages"""
+    schema = [
+        {
+            'label': 'sha',
+            'name': 'SHA',
+            'help': 'Full SHA of the commit.',
+            'type': 'string',
+        },
+        {
+            'label': 'author_name',
+            'name': 'Author Name',
+            'help': 'The author name of the commit.',
+            'type': 'string',
+        },
+        {
+            'label': 'author_email',
+            'name': 'Author Email',
+            'help': 'The author email of the commit.',
+            'type': 'string',
+        },
+        {
+            'label': 'author_date',
+            'name': 'Author Date',
+            'help': 'The time at which the commit was authored.',
+            'type': 'datetime',
+        },
+        {
+            'label': 'committer_name',
+            'name': 'Committer Name',
+            'help': 'The name of the person who performed the commit.',
+            'type': 'string',
+        },
+        {
+            'label': 'committer_email',
+            'name': 'Committer Email',
+            'help': 'The email of the person who performed the commit.',
+            'type': 'string',
+        },
+        {
+            'label': 'committer_date',
+            'name': 'Committer Date',
+            'help': 'The time at which the commit was performed.',
+            'type': 'datetime',
+        },
+    ]
+
+    return formaldict.Schema(schema)
+
+
+def _load_note_schema(path=None):
+    """Loads the detail schema"""
+    path = path or utils.get_detail_schema_path()
+
+    try:
+        with open(path, 'r') as schema_f:
+            schema = yaml.safe_load(schema_f)
+    except IOError:
+        raise exceptions.SchemaError(
+            'Must create a schema.yaml in the ".detail" directory of your project'
+        )
+
+    for entry in schema:
+        if 'label' not in entry:
+            raise exceptions.SchemaError(f'Entry in schema does not have label - {entry}')
+
+    return formaldict.Schema(schema)
+
+
+class Tag(collections.UserString):
+    """A git tag."""
+
+    def __init__(self, tag):
+        self.data = tag
+
+    @classmethod
+    def from_sha(cls, sha, tag_match=None):
+        """
+        Create a Tag object from a sha or return None if there is no
+        associated tag
+
+        Returns:
+            Tag: A constructed tag or ``None`` if no tags contain the commit.
+        """
+        describe_cmd = f'git describe {sha} --contains'
+        if tag_match:
+            describe_cmd += f' --match={tag_match}'
+
+        rev = (
+            utils.shell_stdout(describe_cmd, check=False, stderr=subprocess.PIPE)
+            .replace('~', ':')
+            .replace('^', ':')
+        )
+        return cls(rev.split(':')[0]) if rev else None
+
+    @property
+    def date(self):
+        """
+        Parse the date of the tag
+
+        Returns:
+            datetime: The tag parsed as a datetime object.
+        """
+        if not hasattr(self, '_date'):
+            try:
+                self._date = dateutil.parser.parse(
+                    utils.shell_stdout(f'git log -1 --format=%ad {self}')
+                )
+            except dateutil.parser.ParserError:
+                self._date = None
+
+        return self._date
+
+
+class Commit(collections.UserDict):
+    """
+    A commit object, parsed from a dictionary of formatted
+    commit data. Allows one to easily see the tag.
+    """
+
+    def __init__(self, data, tag_match=None):
+        self.data = data
+        self._tag_match = tag_match
+
+    def __getattribute__(self, attr):
+        try:
+            return object.__getattribute__(self, attr)
+        except AttributeError:
+            if attr in self.data:
+                return self.data[attr]
+            else:
+                raise
+
+    @property
+    def tag(self):
+        """Returns a `Tag` that contains the commit"""
+        if not hasattr(self, '_tag'):
+            self._tag = Tag.from_sha(self.sha, tag_match=self._tag_match)
+
+        return self._tag
+
+
+class Note(collections.UserDict):
+    """
+    A note object with an optional associated commit
+    """
+
+    def __init__(self, data, *, path, schema, commit=None):
+        self.data = data
+        self.path = path
+        self._schema = schema
+        self.commit = commit
+        self.schema_data = schema.parse(data)
+
+    def __getattribute__(self, attr):
+        try:
+            return object.__getattribute__(self, attr)
+        except AttributeError:
+            if self.schema_data and attr in self.schema_data:
+                return self.schema_data[attr]
+            elif attr in self._schema:
+                return None
+            elif self.commit and attr.startswith('commit_') and hasattr(self.commit, attr[7:]):
+                return getattr(self.commit, attr[7:])
+            else:
+                raise
+
+    @property
+    def validation_errors(self):
+        """
+        Returns the schema ``formaldict.Errors`` that occurred during
+        validation
+        """
+        return self.schema_data.errors
+
+    @property
+    def is_valid(self):
+        """
+        ``True`` if the note was successfully validated against
+        the schema. If ``False``, some attributes in the schema may
+        be missing.
+        """
+        return self.schema_data.is_valid
+
+
+def _equals(a, b, match=False):
+    """True if a equals b. If match is True, perform a regex match
+
+    If b is a regex ``Pattern``, applies regex matching
+    """
+    if match:
+        return re.match(b, a) is not None if isinstance(a, str) else False
+    else:
+        return a == b
+
+
+class Notes(collections.abc.Sequence):
+    """A filterable and groupable collection of notes
+
+    When a list of Note objects is organized in this sequence, the
+    "group", "filter", and "exclude" chainable methods can be used
+    for various access patterns. These access patterns are typically
+    used when writing log templates.
+    """
+
+    def __init__(self, notes):
+        self._notes = notes
+
+    def __getitem__(self, i):
+        return self._notes[i]
+
+    def __len__(self):
+        return len(self._notes)
+
+    def filter(self, attr, value, match=False):
+        """Filter notes by an attribute
+
+        Args:
+            attr (str): The name of the attribute on the `Note` object.
+            value (str|bool): The value to filter by.
+            match (bool, default=False): Treat ``value`` as a regex pattern and
+                match against it.
+
+        Returns:
+            `Notes`: The filtered notes.
+        """
+        return Notes([note for note in self if _equals(getattr(note, attr), value, match=match)])
+
+    def exclude(self, attr, value, match=False):
+        """Exclude notes by an attribute
+
+        Args:
+            attr (str): The name of the attribute on the `Note` object.
+            value (str|bool): The value to exclude by.
+            match (bool, default=False): Treat ``value`` as a regex pattern and
+                match against it.
+
+        Returns:
+            `Notes`: The excluded commits.
+        """
+        return Notes(
+            [note for note in self if not _equals(getattr(note, attr), value, match=match)]
+        )
+
+    def group(
+        self,
+        attr,
+        ascending_keys=False,
+        descending_keys=False,
+        none_key_first=False,
+        none_key_last=False,
+    ):
+        """Group notes by an attribute
+
+        Args:
+            attr (str): The attribute to group by.
+            ascending_keys (bool, default=False): Sort the keys in ascending
+                order.
+            descending_keys (bool, default=False): Sort the keys in descending
+                order.
+            none_key_first (bool, default=False): Make the "None" key be first.
+            none_key_last (bool, default=False): Make the "None" key be last.
+
+        Returns:
+            `collections.OrderedDict`: A dictionary of `Notes` keyed on
+            groups.
+        """
+        if any([ascending_keys, descending_keys]) and not any([none_key_first, none_key_last]):
+            # If keys are sorted, default to making the "None" key last
+            none_key_last = True
+
+        # Get the natural ordering of the keys
+        keys = list(collections.OrderedDict((getattr(note, attr), True) for note in self).keys())
+
+        # Re-sort the keys
+        if any([ascending_keys, descending_keys]):
+            sorted_keys = sorted((k for k in keys if k is not None), reverse=descending_keys)
+            if None in keys:
+                sorted_keys.append(None)
+
+            keys = sorted_keys
+
+        # Change the ordering of the "None" key
+        if any([none_key_first, none_key_last]) and None in keys:
+            keys.remove(None)
+            keys.insert(0 if none_key_first else len(keys), None)
+
+        return collections.OrderedDict((key, self.filter(attr, key)) for key in keys)
+
+
+def _get_pull_request_range():
+    base = github.get_pull_request_base()
+    return f'{base}..'
+
+
+def _git_log(git_log_cmd):
+    """
+    Outputs git log in a format parseable as YAML.
+
+    Args:
+        git_log_cmd (str): The primary "git log .." command.
+            This function adds the "--format" parameter to
+            it and cleans the resulting log.
+
+    Returns:
+        List: Commit dictionaries
+    """
+    delimiter = '\n<-------->'
+    git_log_stdout = utils.shell_stdout(
+        f'{git_log_cmd} '
+        '--format="'
+        'sha: %H%n'
+        'author_name: %an%n'
+        'author_email: %ae%n'
+        'author_date: %ad%n'
+        'committer_name: %cn%n'
+        'committer_email: %ce%n'
+        'committer_date: %cd%n'
+        f'%n{delimiter}"'
+        f' -- {utils.get_detail_note_root()}'
+    )
+
+    commit_schema = _load_commit_schema()
+    return [
+        commit_schema.parse(yaml.safe_load(io.StringIO(msg))).data
+        for msg in git_log_stdout.split(delimiter)
+        if msg.strip()
+    ]
+
+
+def _note_log(git_log_cmd):
+    """
+    Return the notes and the associated SHAs of when they were created.
+
+    Args:
+        git_log_cmd (str): The primary "git log .." command.
+            This function adds additional parsing parameters and cleans
+            the log.
+
+    Returns:
+        Dict: The file paths for each git sha
+    """
+    delimiter = '<-------->'
+    git_log_stdout = utils.shell_stdout(
+        f'{git_log_cmd} '
+        f'--format="{delimiter}sha: %H"'
+        f' --diff-filter=A --raw -- {utils.get_detail_note_root()}'
+    )
+
+    shas_to_files = {}
+    msgs = [msg for msg in git_log_stdout.split(delimiter) if msg]
+    for msg in msgs:
+        split = msg.split('\n')
+        sha = split[0][4:].strip()
+        files = [line.split('\t')[1].strip() for line in split[1:] if line.strip()]
+        shas_to_files[sha] = files
+
+    notes = []
+    root = utils.get_root()
+    for sha, files in shas_to_files.items():
+        for file_path in files:
+            try:
+                with open(root / file_path) as f:
+                    file_contents = f.read()
+            except FileNotFoundError:
+                continue
+
+            parsed_contents = yaml.safe_load(file_contents)
+            notes.append((file_path, parsed_contents, sha))
+
+    return notes
+
+
+class NoteRange(Notes):
+    """
+    Represents a range of notes. The range can be filtered and grouped
+    using all of the methods in `Notes`.
+
+    When doing ``git log``, the user can provide a range
+    (e.g. "origin/develop.."). Any range used in "git log" can be
+    used as a range to the NoteRange object.
+
+    If the special ``:github/pr`` value is used as a range, the Github
+    API is used to figure out the range based on a pull request opened
+    from the current branch (if found).
+    """
+
+    def __init__(self, range='', tag_match=None, before=None, after=None, reverse=False):
+        self._commit_schema = _load_commit_schema()
+        self._tag_match = tag_match
+        self._before = before
+        self._after = after
+        self._reverse = reverse
+
+        # The special ":github/pr" range will do a range against the base
+        # pull request branch
+        if range == GITHUB_PR:
+            range = _get_pull_request_range()
+
+        # Ensure any remotes are fetched
+        utils.shell('git --no-pager fetch -q')
+
+        git_log_cmd = f'git --no-pager log {range} --no-merges'
+        if before:
+            git_log_cmd += f' --before={before}'
+        if after:
+            git_log_cmd += f' --after={after}'
+        if reverse:
+            git_log_cmd += ' --reverse'
+
+        commits = {commit['sha']: commit for commit in _git_log(git_log_cmd)}
+        note_log = _note_log(git_log_cmd)
+
+        self._range = range
+        schema = _load_note_schema()
+
+        return super().__init__(
+            [
+                Note(
+                    data,
+                    path=path,
+                    schema=schema,
+                    commit=Commit(commits[sha], tag_match=tag_match),
+                )
+                for path, data, sha in note_log
+                if data
+            ]
+        )
+
+
+def detail(path=None):
+    """
+    Creates or updates a note
+
+    Arguments:
+        path (str, default=None): A path to an existing note.
+            If provided, the note will be updated.
+
+    Returns:
+        subprocess.CompletedProcess: The result from running
+        git commit. Returns the git pre-commit hook results if
+        failing during hook execution.
+    """
+    defaults = {}
+    if path:
+        with open(path) as f:
+            defaults = yaml.safe_load(f.read())
+    else:
+        now = dt.datetime.utcnow()
+        path = (
+            utils.get_detail_note_root()
+            / f'{now.strftime("%Y-%m-%d")}-{str(uuid.uuid4())[:6]}.yaml'
+        )
+        path.parent.mkdir(exist_ok=True)
+
+    schema = _load_note_schema()
+    entry = schema.prompt(defaults=defaults)
+    serialized = yaml.dump(entry.data, default_style='|')
+
+    with open(path, 'w') as f:
+        f.write(serialized)
+
+    return path, entry
+
+
+def lint(range=''):
+    """
+    Lint notes against a range (branch, sha, etc).
+
+    Args:
+        range (str, default=''): The git revision range against which linting
+            happens. The special value of ":github/pr" can be used to lint
+            against the remote branch of the pull request that is opened
+            from the local branch. No range means linting will happen against
+            all commits.
+
+    Raises:
+        `NoGithubPullRequestFoundError`: When using ``:github/pr`` as
+            the range and no pull requests are found.
+        `MultipleGithubPullRequestsFoundError`: When using ``:github/pr`` as
+            the range and multiple pull requests are found.
+
+    Returns:
+        tuple(bool, NoteRange): A tuple of the lint result (True/False)
+        and the associated `NoteRange`
+    """
+    notes = NoteRange(range=range)
+    return not notes.filter('is_valid', False), notes
+
+
+def log(
+    range='',
+    style='default',
+    template=None,
+    tag_match=None,
+    before=None,
+    after=None,
+    reverse=False,
+    output=None,
+):
+    """
+    Renders notes.
+
+    Args:
+        range (str, default=''): The git revision range over which logs are
+            output. Using ":github/pr" as the range will use the base branch
+            of an open github pull request as the range. No range will result
+            in all commits being logged.
+        style (str, default="default"): The template file nickname to use when rendering.
+            Defaults to "default", which means ``.detail/log.tpl`` will
+            be used to render. When used, the ``.detail/log_{{style}}.tpl``
+            file will be rendered.
+        template (str, default=None): A template string to use when rendering.
+            Supercedes any style provided.
+        tag_match (str, default=None): A glob(7) pattern for matching tags
+            when associating a tag with a commit in the log. Passed through
+            to ``git describe --contains --matches`` when finding a tag.
+        before (str, default=None): Only return commits before a specific
+            date. Passed directly to ``git log --before``.
+        after (str, default=None): Only return commits after a specific
+            date. Passed directly to ``git log --after``.
+        reverse (bool, default=False): Reverse ordering of results. Passed
+            directly to ``git log --reverse``.
+        output (str|file): Path or file-like object to which the template is
+            written. Using the special ":github/pr" output path will post the
+            log as a comment on the pull request.
+
+    Raises:
+        `NoGithubPullRequestFoundError`: When using ``:github/pr`` as
+            the range and no pull requests are found.
+        `MultipleGithubPullRequestsFoundError`: When using ``:github/pr`` as
+            the range and multiple pull requests are found.
+
+    Returns:
+        str: The rendered log.
+    """
+    notes = NoteRange(
+        range=range,
+        tag_match=tag_match,
+        before=before,
+        after=after,
+        reverse=reverse,
+    )
+
+    if not template:
+        env = jinja2.Environment(
+            loader=jinja2.FileSystemLoader(utils.get_detail_root()),
+            trim_blocks=True,
+        )
+        template_file = 'log.tpl' if style == 'default' else f'log_{style}.tpl'
+
+        try:
+            template = env.get_template(template_file)
+        except jinja2.exceptions.TemplateNotFound:
+            if style == 'default':
+                # Use the default template if the user didn't provide one
+                template = jinja2.Template(DEFAULT_LOG_TEMPLATE, trim_blocks=True)
+            else:
+                raise
+    else:
+        template = jinja2.Template(template, trim_blocks=True)
+
+    rendered = template.render(notes=notes, output=output, range=range)
+
+    _output(path=output, value=rendered)
+
+    return rendered

--- a/detail/exceptions.py
+++ b/detail/exceptions.py
@@ -1,0 +1,26 @@
+class Error(Exception):
+    """The base error for all detail errors"""
+
+
+class SchemaError(Error):
+    """When an issue is found in the user-supplied schema"""
+
+
+class CommitParseError(Error):
+    """For representing errors when parsing commits"""
+
+
+class GithubConfigurationError(Error):
+    """When not correctly set up for Github access"""
+
+
+class GithubPullRequestAPIError(Error):
+    """When an unexpected error happens with the Github pull request API"""
+
+
+class NoGithubPullRequestFoundError(Error):
+    """When no Github pull requests have been opened"""
+
+
+class MultipleGithubPullRequestsFoundError(Error):
+    """When multiple Github pull requests have been opened"""

--- a/detail/github.py
+++ b/detail/github.py
@@ -1,0 +1,143 @@
+"""
+Utilities for accessing Github
+"""
+
+import os
+
+import requests
+
+from detail import exceptions
+from detail import utils
+
+
+GITHUB_API_TOKEN_ENV_VAR = 'GITHUB_API_TOKEN'
+GITHUB_USERNAME_ENV_VAR = 'GITHUB_USERNAME'
+
+
+def get_org_and_repo_name():
+    remote_url = utils.shell_stdout('git remote get-url origin')
+    if not remote_url:
+        raise exceptions.GithubConfigurationError(
+            'Must have a remote named "origin" in order to work with Github.'
+        )
+
+    org_name, repo_name = remote_url.split(':')[1].split('/')
+
+    assert repo_name.endswith('.git')
+    return org_name, repo_name[0:-4]
+
+
+class GithubClient:
+    """Utility client for accessing Github API"""
+
+    def __init__(self):
+        if not os.environ.get(GITHUB_API_TOKEN_ENV_VAR):  # pragma: no cover
+            raise exceptions.GithubConfigurationError(
+                f'Must set the "{GITHUB_API_TOKEN_ENV_VAR}" environment'
+                ' variable for Github access.'
+            )
+
+        self.api_token = os.environ[GITHUB_API_TOKEN_ENV_VAR]
+
+    def _call_api(self, verb, url, **request_kwargs):
+        """Perform a github API call
+
+        Args:
+            verb (str): Can be "post", "put", or "get"
+            url (str): The base URL with a leading slash for Github API (v3)
+        """
+        api = 'https://api.github.com{}'.format(url)
+        auth_headers = {'Authorization': 'token {}'.format(self.api_token)}
+        headers = {**auth_headers, **request_kwargs.pop('headers', {})}
+        resp = getattr(requests, verb)(api, headers=headers, **request_kwargs)
+        resp.raise_for_status()
+        return resp
+
+    def get(self, url, **request_kwargs):
+        """Github API get"""
+        return self._call_api('get', url, **request_kwargs)
+
+    def post(self, url, **request_kwargs):
+        """Github API post"""
+        return self._call_api('post', url, **request_kwargs)
+
+    def patch(self, url, **request_kwargs):
+        """Github API put"""
+        return self._call_api('patch', url, **request_kwargs)
+
+
+def get_pull_request():
+    """Find the pull request in github
+
+    Raises:
+        NoPullRequestFoundError: If a pull request isn't found
+        MultiplePullRequestsFoundError: If multiple pull requests are
+            opened from the current branch
+    """
+    org_name, repo_name = get_org_and_repo_name()
+    current_branch = utils.shell_stdout("git --no-pager branch | grep \\* | cut -d ' ' -f2")
+
+    try:
+        prs = (
+            GithubClient()
+            .get(f'/repos/{org_name}/{repo_name}/pulls' f'?head={org_name}:{current_branch}')
+            .json()
+        )
+    except requests.exceptions.RequestException as exc:
+        raise exceptions.GithubPullRequestAPIError(
+            'An unexpected error occurred with the Github pull requests' ' API.'
+        ) from exc
+
+    if not prs:
+        raise exceptions.NoGithubPullRequestFoundError(
+            f'No pull requests found for branch "{current_branch}"'
+        )
+
+    if len(prs) > 1:
+        raise exceptions.MultipleGithubPullRequestsFoundError(
+            f'Multiple pull requests found for branch "{current_branch}"'
+        )
+
+    return prs[0]
+
+
+def get_pull_request_base(pr=None):
+    """Find the pull request base branch in github
+
+    Raises:
+        NoPullRequestFoundError: If a pull request isn't found
+        MultiplePullRequestsFoundError: If multiple pull requests are
+            opened from the current branch
+    """
+    pr = pr or get_pull_request()
+    return f"origin/{pr['base']['ref']}"
+
+
+def comment(message):
+    """
+    Comment a message on a pull request
+    """
+    pr = get_pull_request()
+    pr_number = pr['number']
+
+    org_name, repo_name = get_org_and_repo_name()
+    github_username = os.environ.get(GITHUB_USERNAME_ENV_VAR)
+    if not github_username:
+        raise exceptions.GithubConfigurationError(
+            f'Must set "{GITHUB_USERNAME_ENV_VAR}" in order to post comments'
+            ' as a specific user.'
+        )
+
+    # Try to find a comment already created so that it can be edited
+    pr_comments_url = f'/repos/{org_name}/{repo_name}/issues/{pr_number}/comments'
+    pr_comments = GithubClient().get(pr_comments_url).json()
+    pr_comment_id = None
+    for pr_comment in pr_comments:
+        if pr_comment['user']['login'] == github_username:
+            pr_comment_id = pr_comment['id']
+
+    if pr_comment_id:
+        comment_edit_url = f'/repos/{org_name}/{repo_name}/issues/comments/{pr_comment_id}'
+        GithubClient().patch(comment_edit_url, json={'body': message})
+    else:
+        GithubClient().post(pr_comments_url, json={'body': message})

--- a/detail/tests/test_cli.py
+++ b/detail/tests/test_cli.py
@@ -1,0 +1,146 @@
+import sys
+from unittest import mock
+
+import pytest
+
+from detail import cli
+
+
+@pytest.fixture
+def mock_exit(mocker):
+    yield mocker.patch('sys.exit', autospec=True)
+
+
+@pytest.fixture
+def mock_successful_exit(mock_exit):
+    yield
+    mock_exit.assert_called_once_with(0)
+
+
+@pytest.mark.usefixtures('mock_successful_exit')
+def test_detail_v(mocker, capsys):
+    """Test calling detail -v"""
+    mocker.patch.object(sys, 'argv', ['detail', '-v'])
+
+    cli.main()
+
+    out, _ = capsys.readouterr()
+    assert out.startswith('detail ')
+
+
+@pytest.mark.parametrize(
+    'command_args, expected_detail_call',
+    [
+        ([], mock.call(path=None)),
+        (['path'], mock.call(path='path')),
+    ],
+)
+def test_detail(mock_exit, mocker, command_args, expected_detail_call):
+    """Test calling detail"""
+    mocker.patch.object(sys, 'argv', ['detail'] + command_args)
+    patched_detail = mocker.patch(
+        'detail.core.detail',
+        autospec=True,
+        return_value=('path', {}),
+    )
+
+    cli.main()
+
+    assert patched_detail.call_args_list == [expected_detail_call]
+
+
+@pytest.mark.parametrize(
+    'command_args, lint_is_valid, expected_lint_call, expected_stderr',
+    [
+        ([], True, mock.call(''), ''),
+        (['range'], True, mock.call('range'), ''),
+        (
+            ['range'],
+            False,
+            mock.call('range'),
+            (
+                '2 out of 2 notes have failed linting:\n'
+                ".detail/1.yaml: ['error1', 'error2']\n.detail/2.yaml: ['error3', 'error4']\n"
+            ),
+        ),
+    ],
+)
+def test_lint(
+    mock_exit,
+    mocker,
+    capsys,
+    command_args,
+    lint_is_valid,
+    expected_lint_call,
+    expected_stderr,
+):
+    """Test calling detail lint"""
+    mocker.patch.object(sys, 'argv', ['detail', 'lint'] + command_args)
+    notes = mocker.MagicMock(
+        __len__=lambda a: 2,
+        filter=lambda a, b: [
+            mocker.Mock(path='.detail/1.yaml', validation_errors=['error1', 'error2']),
+            mocker.Mock(path='.detail/2.yaml', validation_errors=['error3', 'error4']),
+        ],
+    )
+    patched_lint = mocker.patch(
+        'detail.core.lint', autospec=True, return_value=(lint_is_valid, notes)
+    )
+
+    cli.main()
+
+    _, err = capsys.readouterr()
+    assert patched_lint.call_args_list == [expected_lint_call]
+    mock_exit.assert_called_once_with(0 if lint_is_valid else 1)
+    assert err == expected_stderr
+
+
+@pytest.mark.parametrize(
+    'command_args, expected_log_call',
+    [
+        (  # Verify default parameters are filled out
+            [],
+            mock.call(
+                '',
+                style='default',
+                template=None,
+                tag_match=None,
+                before=None,
+                after=None,
+                reverse=False,
+                output=sys.stdout,
+            ),
+        ),
+        (  # Verify default parameters are filled out
+            [
+                'range',
+                '--style=new',
+                '--tag-match=pattern',
+                '--before=before',
+                '--after=after',
+                '--reverse',
+                '-o',
+                'file',
+            ],
+            mock.call(
+                'range',
+                style='new',
+                template=None,
+                tag_match='pattern',
+                before='before',
+                after='after',
+                reverse=True,
+                output='file',
+            ),
+        ),
+    ],
+)
+@pytest.mark.usefixtures('mock_successful_exit')
+def test_log(mocker, command_args, expected_log_call):
+    """Test calling detail log"""
+    mocker.patch.object(sys, 'argv', ['detail', 'log'] + command_args)
+    patched_commit = mocker.patch('detail.core.log', autospec=True)
+
+    cli.main()
+
+    assert patched_commit.call_args_list == [expected_log_call]

--- a/detail/tests/test_core.py
+++ b/detail/tests/test_core.py
@@ -1,0 +1,121 @@
+"""Tests the detail.core module
+
+Most of the test coverage of the core module is from the integration
+tests in detail/tests/test_integration.py.
+"""
+from contextlib import ExitStack as does_not_raise
+from unittest import mock
+
+import pytest
+
+from detail import core
+from detail import exceptions
+
+
+# A valid user schema
+valid_schema = '''
+- label: type
+- label: summary
+- label: description
+  condition: ['!=', 'type', 'trivial']
+  multiline: True
+  required: False
+ '''
+
+# An invalid user schema
+invalid_schema = '- invalid: type'
+
+
+@pytest.mark.parametrize(
+    'user_schema, expected_exception, expected_schema_labels',
+    [
+        (
+            valid_schema,
+            does_not_raise(),
+            [
+                'type',
+                'summary',
+                'description',
+            ],
+        ),
+        (None, pytest.raises(exceptions.SchemaError), None),
+        (
+            invalid_schema,
+            pytest.raises(exceptions.SchemaError),
+            None,
+        ),
+    ],
+)
+def test_load_note_schema(
+    tmp_path,
+    mocker,
+    user_schema,
+    expected_exception,
+    expected_schema_labels,
+):
+    """Tests core._load_note_schema()"""
+    user_schema_file = tmp_path / 'schema.yaml'
+    if user_schema:
+        user_schema_file.write_text(user_schema)
+
+    with expected_exception:
+        schema = core._load_note_schema(path=user_schema_file)
+        assert [s['label'] for s in schema] == expected_schema_labels
+
+
+@pytest.mark.parametrize(
+    'sha, tag_match, git_describe_output, expected_git_call, expected_tag_value',
+    [
+        ('sha1', None, '0.1~8', 'git describe sha1 --contains', '0.1'),
+        (
+            'sha1',
+            'pattern',
+            '',
+            'git describe sha1 --contains --match=pattern',
+            'None',
+        ),
+    ],
+)
+def test_tag_from_sha(
+    mocker,
+    sha,
+    tag_match,
+    git_describe_output,
+    expected_git_call,
+    expected_tag_value,
+):
+    """Tests core.Tag.from_sha()"""
+    patched_describe = mocker.patch(
+        'detail.utils.shell_stdout',
+        autospec=True,
+        return_value=git_describe_output,
+    )
+
+    assert str(core.Tag.from_sha(sha, tag_match=tag_match)) == expected_tag_value
+    assert patched_describe.call_args_list[0][0][0] == expected_git_call
+
+
+@pytest.mark.parametrize(
+    'git_log_output, expected_git_log_call, expected_date',
+    [('', mock.call('git log -1 --format=%ad 2.1'), None)],
+)
+def test_tag_date(mocker, git_log_output, expected_git_log_call, expected_date):
+    """Tests core.Tag.date()"""
+    patched_shell = mocker.patch(
+        'detail.utils.shell_stdout', autospec=True, return_value=git_log_output
+    )
+    tag = core.Tag('2.1')
+
+    assert tag.date == expected_date
+    assert tag.date == expected_date  # Run twice to exercise caching
+    assert patched_shell.call_args_list == [expected_git_log_call]
+
+
+def test_get_pull_request_range(mocker):
+    """Tests core._get_pull_request_range"""
+    mocker.patch(
+        'detail.github.get_pull_request_base',
+        autospec=True,
+        return_value='develop',
+    )
+    assert core._get_pull_request_range() == 'develop..'

--- a/detail/tests/test_github.py
+++ b/detail/tests/test_github.py
@@ -1,0 +1,234 @@
+"""Tests for the detail.github module"""
+from contextlib import ExitStack as does_not_raise
+import json
+from unittest import mock
+
+import pytest
+import requests
+
+from detail import exceptions
+from detail import github
+
+
+@pytest.fixture(autouse=True)
+def setup_github_env_vars(monkeypatch):
+    monkeypatch.setenv('GITHUB_API_TOKEN', 'github_token')
+
+
+@pytest.mark.parametrize(
+    'git_origin, expected_org_name, expected_repo_name, expected_exception',
+    [
+        (
+            'git@github.com:opus10/random-repo.git',
+            'opus10',
+            'random-repo',
+            does_not_raise(),
+        ),
+        ('', None, None, pytest.raises(exceptions.GithubConfigurationError)),
+    ],
+)
+def test_get_org_and_repo_name(
+    mocker,
+    git_origin,
+    expected_org_name,
+    expected_repo_name,
+    expected_exception,
+):
+    """Tests github.get_org_and_repo_name()"""
+    mocker.patch('detail.utils.shell_stdout', return_value=git_origin, autospec=True)
+    with expected_exception:
+        org_name, repo_name = github.get_org_and_repo_name()
+        assert org_name == expected_org_name
+        assert repo_name == expected_repo_name
+
+
+@pytest.mark.parametrize(
+    'environment, expected_exception',
+    [
+        (  # Initialization fails without GITHUB_API_TOKEN
+            {},
+            pytest.raises(exceptions.GithubConfigurationError),
+        ),
+        ({'GITHUB_API_TOKEN': 'token'}, does_not_raise()),
+    ],
+)
+def test_github_client_init(environment, expected_exception, mocker):
+    """Tests initialization of GithubClient()"""
+    mocker.patch.dict('os.environ', environment, clear=True)
+    with expected_exception:
+        github.GithubClient()
+
+
+def test_github_client_call_api(mocker, responses):
+    """Tests GithubClient._call_api()"""
+    responses.add(responses.POST, 'https://api.github.com/url/base')
+
+    c = github.GithubClient()
+    c._call_api(
+        'post',
+        '/url/base',
+        headers={'additonal': 'header'},
+        data={'post': 'data'},
+    )
+
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.body == 'post=data'
+    assert responses.calls[0].request.headers['additonal'] == 'header'
+    assert responses.calls[0].request.headers['Authorization'] == 'token github_token'
+
+
+def test_github_client_get_patch_post(mocker):
+    """Tests GithubClient.get(), patch(), and post() utility methods"""
+    patched_call_api = mocker.patch.object(github.GithubClient, '_call_api', autospec=True)
+    c = github.GithubClient()
+    c.get('/get/url', get_arg='get')
+    c.patch('/patch/url', patch_arg='patch')
+    c.post('/post/url', post_arg='post')
+
+    assert patched_call_api.call_args_list == [
+        mocker.call(mocker.ANY, 'get', '/get/url', get_arg='get'),
+        mocker.call(mocker.ANY, 'patch', '/patch/url', patch_arg='patch'),
+        mocker.call(mocker.ANY, 'post', '/post/url', post_arg='post'),
+    ]
+
+
+@pytest.mark.parametrize(
+    'api_status, api_return, expected_pr, expected_exception',
+    [
+        (  # When an unexpected Github API error happens
+            500,
+            None,
+            None,
+            pytest.raises(exceptions.GithubPullRequestAPIError),
+        ),
+        (  # When there are no pull requests
+            200,
+            [],
+            None,
+            pytest.raises(exceptions.NoGithubPullRequestFoundError),
+        ),
+        (  # An error is raised if there are multiple pull requests
+            200,
+            [{}, {}],
+            None,
+            pytest.raises(exceptions.MultipleGithubPullRequestsFoundError),
+        ),
+        (200, [{'pr': 'payload'}], {'pr': 'payload'}, does_not_raise()),
+    ],
+)
+def test_get_pull_request(
+    mocker, responses, api_return, api_status, expected_pr, expected_exception
+):
+    """Tests github.get_pull_request()"""
+    mocker.patch(
+        'detail.utils.shell_stdout',
+        autospec=True,
+        side_effect=[
+            # The first shell call gets the git remote branch
+            'git@github.com:jyveapp/random-repo.git',
+            # The second shell call gets the current git branch
+            'current_branch',
+        ],
+    )
+    responses.add(
+        responses.GET,
+        ('https://api.github.com/repos/jyveapp/random-repo/' 'pulls?head=jyveapp:current_branch'),
+        json=api_return,
+        status=api_status,
+    )
+
+    with expected_exception:
+        assert github.get_pull_request() == expected_pr
+
+
+def test_get_pull_request_base(mocker):
+    """Tests github.get_pull_request_base()"""
+    mocker.patch(
+        'detail.github.get_pull_request',
+        autospec=True,
+        return_value={'base': {'ref': 'base_branch'}},
+    )
+
+    assert github.get_pull_request_base() == 'origin/base_branch'
+
+
+@pytest.mark.parametrize(
+    'github_username, pr, pr_comments, expected_client_calls, expected_exception',
+    [
+        (  # A github username must be configured
+            '',
+            {'number': 10},
+            None,
+            None,
+            pytest.raises(exceptions.GithubConfigurationError),
+        ),
+        (  # New PR comments post a new comment message
+            'user',
+            {'number': 10},
+            [{'user': {'login': 'another_user'}}],
+            [
+                mock.call(
+                    mock.ANY,
+                    'get',
+                    '/repos/org_name/repo_name/issues/10/comments',
+                ),
+                mock.call(
+                    mock.ANY,
+                    'post',
+                    '/repos/org_name/repo_name/issues/10/comments',
+                    json={'body': 'message'},
+                ),
+            ],
+            does_not_raise(),
+        ),
+        (  # The comment is patched if it already exists
+            'user',
+            {'number': 10},
+            [{'id': 110, 'user': {'login': 'user'}}],
+            [
+                mock.call(
+                    mock.ANY,
+                    'get',
+                    '/repos/org_name/repo_name/issues/10/comments',
+                ),
+                mock.call(
+                    mock.ANY,
+                    'patch',
+                    '/repos/org_name/repo_name/issues/comments/110',
+                    json={'body': 'message'},
+                ),
+            ],
+            does_not_raise(),
+        ),
+    ],
+)
+def test_comment(
+    mocker,
+    monkeypatch,
+    github_username,
+    pr,
+    pr_comments,
+    expected_client_calls,
+    expected_exception,
+):
+    """Tests github.comment()"""
+    comment_response = requests.Response()
+    comment_response._content = json.dumps(pr_comments).encode()
+    patched_client_call = mocker.patch.object(
+        github.GithubClient,
+        '_call_api',
+        autospec=True,
+        side_effect=[comment_response, None],
+    )
+    monkeypatch.setenv('GITHUB_USERNAME', github_username)
+    mocker.patch('detail.github.get_pull_request', autospec=True, return_value=pr)
+    mocker.patch(
+        'detail.github.get_org_and_repo_name',
+        autospec=True,
+        return_value=('org_name', 'repo_name'),
+    )
+
+    with expected_exception:
+        github.comment('message')
+
+        assert patched_client_call.call_args_list == expected_client_calls

--- a/detail/tests/test_integration.py
+++ b/detail/tests/test_integration.py
@@ -1,0 +1,408 @@
+"""Integration tests for detail"""
+from contextlib import ExitStack as does_not_raise
+import io
+import os
+import pathlib
+import shutil
+
+import formaldict
+import jinja2.exceptions
+import pytest
+import yaml
+
+from detail import core
+from detail import utils
+
+
+@pytest.fixture()
+def detail_config(tmp_path, mocker):
+    """Creates an example detail config for integration tests"""
+    detail_root = tmp_path / '.detail'
+    detail_root.mkdir()
+
+    detail_commit_config = detail_root / 'schema.yaml'
+    detail_commit_config.write_text(
+        '- label: type\n'
+        '  name: Type\n'
+        '  help: The type of change.\n'
+        '  type: string\n'
+        '  choices:\n'
+        '      - api-break\n'
+        '      - bug\n'
+        '      - feature\n'
+        '      - trivial\n'
+        '\n'
+        '- label: summary\n'
+        '  name: Summary\n'
+        '  help: A high-level summary of the changes.\n'
+        '  type: string\n'
+        '\n'
+        '- label: description\n'
+        '  name: Description\n'
+        '  help: An in-depth description of the changes.\n'
+        '  type: string\n'
+        '  condition: ["!=", "type", "trivial"]\n'
+        '  multiline: True\n'
+        '  required: False\n'
+        '\n'
+        '- label: jira\n'
+        '  name: Jira\n'
+        '  help: Jira Ticket ID.\n'
+        '  type: string\n'
+        '  required: false\n'
+        '  condition: ["!=", "type", "trivial"]\n'
+        '  matches: WEB-[\\d]+\n'
+        '\n'
+        '- label: component\n'
+        '  type: string\n'
+        '  required: false\n'
+        '  condition: ["!=", "type", "trivial"]\n'
+    )
+
+    detail_commit_template = detail_root / 'log.tpl'
+    detail_commit_template.write_text(
+        '{% for tag, notes_by_tag in notes.group("commit_tag").items() %}\n'
+        '# {{ tag|default("Unreleased", True) }} '
+        '{% if tag.date %}({{ tag.date.date() }}){% endif %}\n'
+        '\n'
+        '{% for type, notes_by_type in '
+        'notes_by_tag.group("type", '
+        'ascending_keys=True, none_key_last=True).items() %}\n'
+        '## {{ type|default("Other", True)|title }}\n'
+        '{% for note in notes_by_type %}\n'
+        '- {{ note.summary }} [{{ note.commit_author_name }}, {{ note.commit_sha }}]\n'
+        '{% if note.description %}\n'
+        '\n'
+        '  {{ note.description }}\n'
+        '{% endif %}\n'
+        '{% endfor %}\n'
+        '{% endfor %}\n'
+        '\n'
+        '{% endfor %}\n'
+    )
+
+    mocker.patch(
+        'detail.utils.get_detail_root',
+        return_value=pathlib.Path(detail_root),
+        autospec=True,
+    )
+
+    utils.get_detail_note_root().mkdir()
+
+    yield tmp_path
+
+
+@pytest.fixture()
+def detail_repo(detail_config):
+    """Create a git repo with for integration tests"""
+    cwd = os.getcwd()
+    os.chdir(detail_config)
+
+    utils.shell('git init .')
+    utils.shell('git config user.email "you@example.com"')
+    utils.shell('git config user.name "Your Name"')
+
+    with open(utils.get_detail_note_root() / 'note1.yaml', 'w') as f:
+        f.write(
+            'summary: Summary1 [skip ci]\ndescription: Description1\n'
+            'type: api-break\njira: WEB-1111\n'
+        )
+
+    utils.shell('git add .')
+    utils.shell('git commit -m "commit"')
+
+    with open(utils.get_detail_note_root() / 'note2.yaml', 'w') as f:
+        f.write('summary: Summary2\ndescription: Description2\ntype: bug\njira: WEB-1112\n')
+
+    utils.shell('git add .')
+    utils.shell('git commit -m "commit"')
+    utils.shell('git tag v1.1')
+
+    with open(utils.get_detail_note_root() / 'note3.yaml', 'w') as f:
+        f.write('summary: Summary3\ntype: trivial\n')
+
+    utils.shell('git add .')
+    utils.shell('git commit -m "commit"')
+    utils.shell('git tag dev1.2')
+    utils.shell('git tag v1.2')
+
+    with open(utils.get_detail_note_root() / 'note4.yaml', 'w') as f:
+        f.write('summary: Summary4\ndescription: Description4\ntype: feature\njira: WEB-1113\n')
+
+    utils.shell('git add .')
+    utils.shell('git commit -m "commit"')
+
+    with open(utils.get_detail_note_root() / 'note5.yaml', 'w') as f:
+        f.write('summary: Invalid5\ndescription: Hi\ntype: feature\njira: INVALID\n')
+
+    utils.shell('git add .')
+    utils.shell('git commit -m "commit"')
+
+    utils.shell('git commit --allow-empty -m $"Invalid5\n\n' 'Type: feature\nJira: INVALID"')
+    # Create a commit that uses the same delimiter structure as detail
+    # to create a scenario of an unparseable commit.
+    # utils.shell('git commit --allow-empty -m $"Invalid6\n\nUnparseable: *{*"')
+
+    yield detail_config
+
+    os.chdir(cwd)
+
+
+@pytest.mark.usefixtures('detail_repo')
+def test_detail_log():
+    """
+    Integration test for detail-log
+    """
+    full_log = utils.shell_stdout('detail log')
+    assert full_log.startswith('# Unreleased')
+    assert '# v1.2' not in full_log  # dev1.2 takes precedence in this case
+    assert '# dev1.2' in full_log
+    assert '# v1.1' in full_log
+
+
+@pytest.mark.usefixtures('detail_repo')
+def test_detail_log_custom_template():
+    """
+    Integration test for detail-log with a custom template
+    """
+    full_log = utils.shell_stdout(
+        'detail log --template="{% for note in notes %}{{note.commit_tag}}\n{% endfor %}"'
+    )
+    assert full_log == 'None\nNone\ndev1.2\nv1.1\nv1.1'
+
+
+@pytest.mark.usefixtures('detail_repo')
+def test_commit_properties_and_range_filtering(mocker):
+    """
+    Integration test for core.NoteRange filtering, grouping, and excluding
+    and core Commit properties
+    """
+    nr = core.NoteRange()
+
+    # Check various commit properties
+    invalid_note = list(nr.filter('is_valid', False))[0]
+    assert (
+        str(invalid_note.validation_errors)
+        == 'jira: Value "INVALID" does not match pattern "WEB-[\\d]+".'
+    )
+    assert invalid_note.type == 'feature'
+    assert not invalid_note.is_valid
+    with pytest.raises(AttributeError):
+        invalid_note.invalid_attribute
+    assert invalid_note.jira is None
+    assert invalid_note.commit_tag is None
+
+    api_break_note = list(nr.filter('type', 'api-break'))[0]
+    assert str(api_break_note.commit.tag) == 'v1.1'
+
+    # Check various filterings on the range
+    assert len(nr.filter('is_valid', True)) == 4
+    assert len(nr.filter('is_valid', False)) == 1
+    assert len(nr.exclude('is_valid', False)) == 4
+    assert len(nr.filter('type', 'feature').filter('is_valid', True)) == 1
+    assert len(nr.filter('summary', r'.*\[skip ci\].*', match=True)) == 1
+    assert len(nr.exclude('summary', r'.*\[skip ci\].*', match=True)) == 4
+
+    # Check groupings
+    tag_groups = nr.group('commit_tag')
+    assert len(tag_groups) == 3
+    assert len(tag_groups[None]) == 2
+    assert len(tag_groups['v1.1']) == 2
+    assert len(tag_groups['dev1.2']) == 1
+    assert len(tag_groups[None].group('type')) == 1
+    assert list(tag_groups['v1.1'].group('type', ascending_keys=True)) == [
+        'api-break',
+        'bug',
+    ]
+
+    type_groups = nr.group('type')
+    assert len(type_groups) == 4
+    assert len(type_groups['api-break']) == 1
+    assert len(type_groups['bug']) == 1
+    assert len(type_groups['feature']) == 2
+    assert len(type_groups['trivial']) == 1
+
+    # Check group sorting
+    assert list(nr.group('commit_tag', ascending_keys=True)) == [
+        'dev1.2',
+        'v1.1',
+        None,
+    ]
+    assert list(nr.group('commit_tag', descending_keys=True)) == [
+        'v1.1',
+        'dev1.2',
+        None,
+    ]
+    assert list(nr.group('commit_tag', ascending_keys=True, none_key_first=True)) == [
+        None,
+        'dev1.2',
+        'v1.1',
+    ]
+    assert list(nr.group('commit_tag', descending_keys=True, none_key_first=True)) == [
+        None,
+        'v1.1',
+        'dev1.2',
+    ]
+
+    # Try matching on the v* tags (no dev tags)
+    nr = core.NoteRange(tag_match='v*')
+    assert set(nr.group('commit_tag')) == {None, 'v1.1', 'v1.2'}
+
+    # Try before/after filtering
+    assert not list(core.NoteRange(before='2019-01-01'))
+    assert len(core.NoteRange(after='2019-01-01')) == 5
+    assert not list(core.NoteRange(after='2019-01-01', before='2019-01-01'))
+
+    # Try reversing commits
+    assert list(core.NoteRange(tag_match='v*', reverse=True))[0].type == 'api-break'
+
+    # Get a commit range over a github PR
+    mocker.patch('detail.core._get_pull_request_range', autospec=True, return_value='')
+
+    nr = core.NoteRange(':github/pr')
+    assert len(nr) == 5
+
+
+@pytest.mark.parametrize(
+    'input_data',
+    [
+        {
+            'type': 'bug',
+            'summary': 'summary!',
+            'description': 'description!',
+            'jira': 'WEB-9999',
+        },
+        # Tests a scenario where a key is empty.
+        {
+            'type': 'feature',
+            'summary': 'summary',
+            'description': 'description',
+            'jira': '',
+        },
+        # Tests a scenario where twos keys are empty.
+        {
+            'type': 'feature',
+            'summary': 'summary',
+            'description': 'description',
+            'jira': '',
+            'component': '',
+        },
+        # Tests committing key with double quotes
+        {
+            'type': 'feature',
+            'summary': 'summary',
+            'description': '"description"',
+            'jira': '',
+            'component': '"""',
+        },
+    ],
+)
+@pytest.mark.usefixtures('detail_repo')
+def test_detail(mocker, input_data):
+    """Tests core.detail and verifies the resulting note."""
+    mocker.patch.object(
+        formaldict.Schema, 'prompt', autospec=True, return_value=mocker.Mock(data=input_data)
+    )
+
+    path, entry = core.detail()
+
+    assert entry.data == input_data
+    with open(path) as f:
+        assert yaml.safe_load(f.read()) == input_data
+
+
+@pytest.mark.usefixtures('detail_repo')
+def test_detail_update(mocker):
+    """Tests core.detail while updating a note."""
+    input_data = {
+        'type': 'bug',
+        'summary': 'summary!',
+        'description': 'description!',
+        'jira': 'WEB-9999',
+    }
+    patch = mocker.patch.object(
+        formaldict.Schema, 'prompt', autospec=True, return_value=mocker.Mock(data=input_data)
+    )
+    path, entry = core.detail()
+
+    update_data = {
+        'type': 'bug',
+        'summary': 'summary!',
+        'description': 'description!',
+        'jira': 'WEB-1000',
+    }
+    patch.return_value = mocker.Mock(data=update_data)
+    new_path, entry = core.detail(path)
+
+    assert new_path == path
+
+    assert entry.data == update_data
+    with open(path) as f:
+        assert yaml.safe_load(f.read()) == update_data
+
+
+@pytest.mark.usefixtures('detail_repo')
+def test_lint():
+    """Tests core.lint()"""
+    passed, commits = core.lint()
+    assert not passed
+    assert len(commits) == 5
+
+
+@pytest.mark.parametrize('output', [None, 'output_file', io.StringIO(), ':github/pr'])
+@pytest.mark.usefixtures('detail_repo')
+def test_log(output, mocker):
+    """Tests core.log() with various output targets"""
+    patched_github = mocker.patch('detail.github.comment', autospec=True)
+    rendered = core.log(output=output)
+
+    if isinstance(output, str) and output != ':github/pr':
+        with open(output) as f:
+            rendered = f.read()
+    elif output == ':github/pr':
+        assert patched_github.called
+    elif output is not None:
+        rendered = output.getvalue()
+
+    assert rendered.startswith('# Unreleased')
+    assert '# dev1.2 (' in rendered
+    assert '## Api-Break' in rendered
+
+
+@pytest.mark.parametrize(
+    'style, expected_exception',
+    [
+        ('default', does_not_raise()),
+        (
+            'custom',
+            pytest.raises(jinja2.exceptions.TemplateNotFound, match='log_custom.tpl'),
+        ),
+    ],
+)
+@pytest.mark.usefixtures('detail_repo')
+def test_log_no_template(style, expected_exception):
+    """
+    Tests core.log() when no template is present. The default detail template
+    should be used when the default style is provided
+    """
+    os.remove('.detail/log.tpl')
+    with expected_exception:
+        rendered = core.log(style=style)
+
+        assert '# v1.2' not in rendered  # dev1.2 takes precedence in this case
+        assert '# dev1.2' in rendered
+        assert '# v1.1' in rendered
+        assert 'Unreleased' in rendered
+        assert 'Description1' in rendered
+        assert 'Summary1' in rendered
+
+
+@pytest.mark.usefixtures('detail_repo')
+def test_log_deleted_files():
+    """
+    Tests core.log() when no template is present. The default detail template
+    should be used when the default style is provided
+    """
+    shutil.rmtree('.detail/notes')
+    rendered = core.log()
+    assert not rendered.strip()

--- a/detail/tests/test_utils.py
+++ b/detail/tests/test_utils.py
@@ -1,0 +1,43 @@
+"""Tests the detail.utils() module"""
+from detail import utils
+
+
+def test_shell_stdout():
+    """Tests utils.shell_stdout()"""
+    assert utils.shell_stdout('echo "hello world"') == 'hello world'
+
+
+def test_get_root(mocker):
+    """Tests utils.get_root()"""
+    mocker.patch(
+        'detail.utils.shell_stdout',
+        autospec=True,
+        # Return value for "git rev-parse --show-toplevel" call
+        return_value='/work',
+    )
+
+    assert str(utils.get_root()) == '/work'
+
+
+def test_get_detail_schema_path(mocker):
+    """Tests utils.get_detail_schema_path()"""
+    mocker.patch(
+        'detail.utils.shell_stdout',
+        autospec=True,
+        # Return value for "git rev-parse --show-toplevel" call
+        return_value='/work',
+    )
+
+    assert str(utils.get_detail_schema_path()) == '/work/.detail/schema.yaml'
+
+
+def test_get_detail_note_root(mocker):
+    """Tests utils.get_detail_note_root()"""
+    mocker.patch(
+        'detail.utils.shell_stdout',
+        autospec=True,
+        # Return value for "git rev-parse --show-toplevel" call
+        return_value='/work',
+    )
+
+    assert str(utils.get_detail_note_root()) == '/work/.detail/notes'

--- a/detail/tests/test_version.py
+++ b/detail/tests/test_version.py
@@ -1,0 +1,5 @@
+import detail
+
+
+def test_version():
+    assert detail.__version__

--- a/detail/utils.py
+++ b/detail/utils.py
@@ -1,0 +1,46 @@
+"""
+Utilities for detail
+"""
+
+import pathlib
+import subprocess
+
+
+def shell(cmd, check=True, stdin=None, stdout=None, stderr=None):
+    """Runs a subprocess shell with check=True by default"""
+    return subprocess.run(cmd, shell=True, check=check, stdin=stdin, stdout=stdout, stderr=stderr)
+
+
+def shell_stdout(cmd, check=True, stdin=None, stderr=None):
+    """Runs a shell command and returns stdout"""
+    ret = shell(cmd, stdout=subprocess.PIPE, check=check, stdin=stdin, stderr=stderr)
+    return ret.stdout.decode('utf-8').strip() if ret.stdout else ''
+
+
+def get_root():
+    """
+    Get the root path in the git project
+    """
+    top_level = shell_stdout('git rev-parse --show-toplevel')
+    return pathlib.Path(top_level)
+
+
+def get_detail_root():
+    """
+    Get the detail storage path in the git project
+    """
+    return get_root() / '.detail'
+
+
+def get_detail_schema_path():
+    """
+    Get the default schema path
+    """
+    return get_detail_root() / 'schema.yaml'
+
+
+def get_detail_note_root():
+    """
+    The root path where notes are stored
+    """
+    return get_detail_root() / 'notes'

--- a/detail/version.py
+++ b/detail/version.py
@@ -1,0 +1,6 @@
+try:
+    from importlib import metadata
+except ImportError:
+    import importlib_metadata as metadata
+
+__version__ = metadata.version('detail')

--- a/devops.py
+++ b/devops.py
@@ -123,9 +123,8 @@ def _generate_changelog_and_tag(old_version, new_version):
     _shell('git tidy-log > CHANGELOG.md')
 
     # Generate a requirements.txt for readthedocs.org
-    _shell('echo "poetry" > docs/requirements.txt')
+    _shell('poetry export --dev --without-hashes -f requirements.txt > docs/requirements.txt')
     _shell('echo "." >> docs/requirements.txt')
-    _shell('poetry export --dev --without-hashes -f requirements.txt ' '>> docs/requirements.txt')
 
     # Add all updated files
     _shell('git add pyproject.toml CHANGELOG.md docs/requirements.txt')

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,0 +1,1399 @@
+[[package]]
+name = "alabaster"
+version = "0.7.12"
+description = "A configurable sidebar-enabled Sphinx theme"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "arrow"
+version = "1.2.2"
+description = "Better dates & times for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+python-dateutil = ">=2.7.0"
+typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
+
+[[package]]
+name = "atomicwrites"
+version = "1.4.0"
+description = "Atomic file writes."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "attrs"
+version = "21.4.0"
+description = "Classes Without Boilerplate"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.extras]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
+docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
+
+[[package]]
+name = "babel"
+version = "2.9.1"
+description = "Internationalization utilities"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.dependencies]
+pytz = ">=2015.7"
+
+[[package]]
+name = "binaryornot"
+version = "0.4.4"
+description = "Ultra-lightweight pure Python package to check if a file is binary or text."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+chardet = ">=3.0.2"
+
+[[package]]
+name = "black"
+version = "22.1.0"
+description = "The uncompromising code formatter."
+category = "dev"
+optional = false
+python-versions = ">=3.6.2"
+
+[package.dependencies]
+click = ">=8.0.0"
+mypy-extensions = ">=0.4.3"
+pathspec = ">=0.9.0"
+platformdirs = ">=2"
+tomli = ">=1.1.0"
+typed-ast = {version = ">=1.4.2", markers = "python_version < \"3.8\" and implementation_name == \"cpython\""}
+typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
+
+[package.extras]
+colorama = ["colorama (>=0.4.3)"]
+d = ["aiohttp (>=3.7.4)"]
+jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
+uvloop = ["uvloop (>=0.15.2)"]
+
+[[package]]
+name = "certifi"
+version = "2021.10.8"
+description = "Python package for providing Mozilla's CA Bundle."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "chardet"
+version = "4.0.0"
+description = "Universal encoding detector for Python 2 and 3"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "charset-normalizer"
+version = "2.0.12"
+description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
+category = "main"
+optional = false
+python-versions = ">=3.5.0"
+
+[package.extras]
+unicode_backport = ["unicodedata2"]
+
+[[package]]
+name = "click"
+version = "8.0.4"
+description = "Composable command line interface toolkit"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+
+[[package]]
+name = "click-default-group"
+version = "1.2.2"
+description = "Extends click.Group to invoke a command without explicit subcommand name"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+click = "*"
+
+[[package]]
+name = "colorama"
+version = "0.4.4"
+description = "Cross-platform colored terminal text."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "cookiecutter"
+version = "1.7.3"
+description = "A command-line utility that creates projects from project templates, e.g. creating a Python package project from a Python package project template."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.dependencies]
+binaryornot = ">=0.4.4"
+click = ">=7.0"
+Jinja2 = ">=2.7,<4.0.0"
+jinja2-time = ">=0.2.0"
+poyo = ">=0.5.0"
+python-slugify = ">=4.0.0"
+requests = ">=2.23.0"
+six = ">=1.10"
+
+[[package]]
+name = "coverage"
+version = "6.3.2"
+description = "Code coverage measurement for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+tomli = {version = "*", optional = true, markers = "extra == \"toml\""}
+
+[package.extras]
+toml = ["tomli"]
+
+[[package]]
+name = "distlib"
+version = "0.3.4"
+description = "Distribution utilities"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "docutils"
+version = "0.17.1"
+description = "Docutils -- Python Documentation Utilities"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "filelock"
+version = "3.6.0"
+description = "A platform independent file lock."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["furo (>=2021.8.17b43)", "sphinx (>=4.1)", "sphinx-autodoc-typehints (>=1.12)"]
+testing = ["covdefaults (>=1.2.0)", "coverage (>=4)", "pytest (>=4)", "pytest-cov", "pytest-timeout (>=1.4.2)"]
+
+[[package]]
+name = "flake8"
+version = "3.9.2"
+description = "the modular source code checker: pep8 pyflakes and co"
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[package.dependencies]
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+mccabe = ">=0.6.0,<0.7.0"
+pycodestyle = ">=2.7.0,<2.8.0"
+pyflakes = ">=2.3.0,<2.4.0"
+
+[[package]]
+name = "flake8-bugbear"
+version = "22.1.11"
+description = "A plugin for flake8 finding likely bugs and design problems in your program. Contains warnings that don't belong in pyflakes and pycodestyle."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+attrs = ">=19.2.0"
+flake8 = ">=3.0.0"
+
+[package.extras]
+dev = ["coverage", "hypothesis", "hypothesmith (>=0.2)", "pre-commit"]
+
+[[package]]
+name = "flake8-comprehensions"
+version = "3.8.0"
+description = "A flake8 plugin to help you write better list/set/dict comprehensions."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+flake8 = ">=3.0,<3.2.0 || >3.2.0"
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+
+[[package]]
+name = "flake8-import-order"
+version = "0.18.1"
+description = "Flake8 and pylama plugin that checks the ordering of import statements."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pycodestyle = "*"
+
+[[package]]
+name = "flake8-logging-format"
+version = "0.6.0"
+description = "Flake8 extension to validate (lack of) logging format strings"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "flake8-mutable"
+version = "1.2.0"
+description = "mutable defaults flake8 extension"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+flake8 = "*"
+
+[[package]]
+name = "formaldict"
+version = "1.0.3"
+description = "Formal structured dictionaries parsed from a schema"
+category = "main"
+optional = false
+python-versions = ">=3.7.0,<4"
+
+[package.dependencies]
+kmatch = ">=0.3.0"
+prompt-toolkit = ">=3.0.2"
+python-dateutil = ">=2.8.1"
+
+[[package]]
+name = "git-tidy"
+version = "1.1.1"
+description = "Tidy git commit messages, linting, and logging"
+category = "dev"
+optional = false
+python-versions = ">=3.7.0,<4"
+
+[package.dependencies]
+click = ">7.0"
+formaldict = ">0.2.0"
+jinja2 = ">2.10.3"
+packaging = ">20.0"
+python-dateutil = ">2.8.1"
+pyyaml = ">5.1.2"
+requests = ">2.22.0"
+
+[[package]]
+name = "idna"
+version = "3.3"
+description = "Internationalized Domain Names in Applications (IDNA)"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
+name = "imagesize"
+version = "1.3.0"
+description = "Getting image size from png/jpeg/jpeg2000/gif file"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "importlib-metadata"
+version = "4.11.3"
+description = "Read metadata from Python packages"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
+zipp = ">=0.5"
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
+perf = ["ipython"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "importlib-resources (>=1.3)"]
+
+[[package]]
+name = "iniconfig"
+version = "1.1.1"
+description = "iniconfig: brain-dead simple config-ini parsing"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "jinja2"
+version = "3.0.3"
+description = "A very fast and expressive template engine."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+MarkupSafe = ">=2.0"
+
+[package.extras]
+i18n = ["Babel (>=2.7)"]
+
+[[package]]
+name = "jinja2-time"
+version = "0.2.0"
+description = "Jinja2 Extension for Dates and Times"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+arrow = "*"
+jinja2 = "*"
+
+[[package]]
+name = "kmatch"
+version = "0.4.0"
+description = "A language for matching/validating/filtering Python dictionaries"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "markupsafe"
+version = "2.1.1"
+description = "Safely add untrusted strings to HTML/XML markup."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "mccabe"
+version = "0.6.1"
+description = "McCabe checker, plugin for flake8"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "mypy-extensions"
+version = "0.4.3"
+description = "Experimental type system extensions for programs checked with the mypy typechecker."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "packaging"
+version = "21.3"
+description = "Core utilities for Python packages"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
+
+[[package]]
+name = "pathspec"
+version = "0.9.0"
+description = "Utility library for gitignore style pattern matching of file paths."
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[[package]]
+name = "platformdirs"
+version = "2.5.1"
+description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["Sphinx (>=4)", "furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)"]
+test = ["appdirs (==1.4.4)", "pytest (>=6)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)"]
+
+[[package]]
+name = "pluggy"
+version = "1.0.0"
+description = "plugin and hook calling mechanisms for python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
+name = "poyo"
+version = "0.5.0"
+description = "A lightweight YAML Parser for Python. 🐓"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.28"
+description = "Library for building powerful interactive command lines in Python"
+category = "main"
+optional = false
+python-versions = ">=3.6.2"
+
+[package.dependencies]
+wcwidth = "*"
+
+[[package]]
+name = "py"
+version = "1.11.0"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "pycodestyle"
+version = "2.7.0"
+description = "Python style guide checker"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "pyflakes"
+version = "2.3.1"
+description = "passive checker of Python programs"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "pygments"
+version = "2.11.2"
+description = "Pygments is a syntax highlighting package written in Python."
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
+name = "pyparsing"
+version = "3.0.7"
+description = "Python parsing module"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+diagrams = ["jinja2", "railroad-diagrams"]
+
+[[package]]
+name = "pytest"
+version = "6.2.5"
+description = "pytest: simple powerful testing with Python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
+attrs = ">=19.2.0"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=0.12,<2.0"
+py = ">=1.8.2"
+toml = "*"
+
+[package.extras]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
+
+[[package]]
+name = "pytest-cov"
+version = "3.0.0"
+description = "Pytest plugin for measuring coverage."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+coverage = {version = ">=5.2.1", extras = ["toml"]}
+pytest = ">=4.6"
+
+[package.extras]
+testing = ["fields", "hunter", "process-tests", "six", "pytest-xdist", "virtualenv"]
+
+[[package]]
+name = "pytest-mock"
+version = "3.7.0"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+pytest = ">=5.0"
+
+[package.extras]
+dev = ["pre-commit", "tox", "pytest-asyncio"]
+
+[[package]]
+name = "pytest-responses"
+version = "0.5.0"
+description = "py.test integration for responses"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pytest = ">=2.5"
+responses = "*"
+
+[package.extras]
+tests = ["flake8"]
+
+[[package]]
+name = "python-dateutil"
+version = "2.8.2"
+description = "Extensions to the standard Python datetime module"
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
+name = "python-slugify"
+version = "6.1.1"
+description = "A Python slugify application that also handles Unicode"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+
+[package.dependencies]
+text-unidecode = ">=1.3"
+
+[package.extras]
+unidecode = ["Unidecode (>=1.1.1)"]
+
+[[package]]
+name = "pytz"
+version = "2022.1"
+description = "World timezone definitions, modern and historical"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "pyyaml"
+version = "6.0"
+description = "YAML parser and emitter for Python"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "requests"
+version = "2.27.1"
+description = "Python HTTP for Humans."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+charset-normalizer = {version = ">=2.0.0,<2.1.0", markers = "python_version >= \"3\""}
+idna = {version = ">=2.5,<4", markers = "python_version >= \"3\""}
+urllib3 = ">=1.21.1,<1.27"
+
+[package.extras]
+socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
+use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
+
+[[package]]
+name = "responses"
+version = "0.20.0"
+description = "A utility library for mocking out the `requests` Python library."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+requests = ">=2.0,<3.0"
+urllib3 = ">=1.25.10"
+
+[package.extras]
+tests = ["pytest (>=7.0.0)", "coverage (>=6.0.0)", "pytest-cov", "pytest-asyncio", "pytest-localserver", "flake8", "types-mock", "types-requests", "mypy"]
+
+[[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "snowballstemmer"
+version = "2.2.0"
+description = "This package provides 29 stemmers for 28 languages generated from Snowball algorithms."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "sphinx"
+version = "4.4.0"
+description = "Python documentation generator"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+alabaster = ">=0.7,<0.8"
+babel = ">=1.3"
+colorama = {version = ">=0.3.5", markers = "sys_platform == \"win32\""}
+docutils = ">=0.14,<0.18"
+imagesize = "*"
+importlib-metadata = {version = ">=4.4", markers = "python_version < \"3.10\""}
+Jinja2 = ">=2.3"
+packaging = "*"
+Pygments = ">=2.0"
+requests = ">=2.5.0"
+snowballstemmer = ">=1.1"
+sphinxcontrib-applehelp = "*"
+sphinxcontrib-devhelp = "*"
+sphinxcontrib-htmlhelp = ">=2.0.0"
+sphinxcontrib-jsmath = "*"
+sphinxcontrib-qthelp = "*"
+sphinxcontrib-serializinghtml = ">=1.1.5"
+
+[package.extras]
+docs = ["sphinxcontrib-websupport"]
+lint = ["flake8 (>=3.5.0)", "isort", "mypy (>=0.931)", "docutils-stubs", "types-typed-ast", "types-requests"]
+test = ["pytest", "pytest-cov", "html5lib", "cython", "typed-ast"]
+
+[[package]]
+name = "sphinx-click"
+version = "3.0.0"
+description = "Sphinx extension that automatically documents click applications"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+click = ">=6.0"
+docutils = "*"
+sphinx = ">=2.0"
+
+[[package]]
+name = "sphinx-rtd-theme"
+version = "1.0.0"
+description = "Read the Docs theme for Sphinx"
+category = "dev"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
+
+[package.dependencies]
+docutils = "<0.18"
+sphinx = ">=1.6"
+
+[package.extras]
+dev = ["transifex-client", "sphinxcontrib-httpdomain", "bump2version"]
+
+[[package]]
+name = "sphinxcontrib-applehelp"
+version = "1.0.2"
+description = "sphinxcontrib-applehelp is a sphinx extension which outputs Apple help books"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.extras]
+lint = ["flake8", "mypy", "docutils-stubs"]
+test = ["pytest"]
+
+[[package]]
+name = "sphinxcontrib-devhelp"
+version = "1.0.2"
+description = "sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp document."
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.extras]
+lint = ["flake8", "mypy", "docutils-stubs"]
+test = ["pytest"]
+
+[[package]]
+name = "sphinxcontrib-htmlhelp"
+version = "2.0.0"
+description = "sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+lint = ["flake8", "mypy", "docutils-stubs"]
+test = ["pytest", "html5lib"]
+
+[[package]]
+name = "sphinxcontrib-jsmath"
+version = "1.0.1"
+description = "A sphinx extension which renders display math in HTML via JavaScript"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.extras]
+test = ["pytest", "flake8", "mypy"]
+
+[[package]]
+name = "sphinxcontrib-qthelp"
+version = "1.0.3"
+description = "sphinxcontrib-qthelp is a sphinx extension which outputs QtHelp document."
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.extras]
+lint = ["flake8", "mypy", "docutils-stubs"]
+test = ["pytest"]
+
+[[package]]
+name = "sphinxcontrib-serializinghtml"
+version = "1.1.5"
+description = "sphinxcontrib-serializinghtml is a sphinx extension which outputs \"serialized\" HTML files (json and pickle)."
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.extras]
+lint = ["flake8", "mypy", "docutils-stubs"]
+test = ["pytest"]
+
+[[package]]
+name = "temple"
+version = "1.4.7"
+description = "Templated project management"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+click = ">=6.7"
+cookiecutter = ">=1.6.0"
+pyyaml = ">=3.12"
+requests = ">=2.13.0"
+
+[[package]]
+name = "text-unidecode"
+version = "1.3"
+description = "The most basic Text::Unidecode port"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "toml"
+version = "0.10.2"
+description = "Python Library for Tom's Obvious, Minimal Language"
+category = "dev"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "tomli"
+version = "2.0.1"
+description = "A lil' TOML parser"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "tox"
+version = "3.24.5"
+description = "tox is a generic virtualenv management and test command line tool"
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[package.dependencies]
+colorama = {version = ">=0.4.1", markers = "platform_system == \"Windows\""}
+filelock = ">=3.0.0"
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+packaging = ">=14"
+pluggy = ">=0.12.0"
+py = ">=1.4.17"
+six = ">=1.14.0"
+toml = ">=0.9.4"
+virtualenv = ">=16.0.0,<20.0.0 || >20.0.0,<20.0.1 || >20.0.1,<20.0.2 || >20.0.2,<20.0.3 || >20.0.3,<20.0.4 || >20.0.4,<20.0.5 || >20.0.5,<20.0.6 || >20.0.6,<20.0.7 || >20.0.7"
+
+[package.extras]
+docs = ["pygments-github-lexers (>=0.0.5)", "sphinx (>=2.0.0)", "sphinxcontrib-autoprogram (>=0.1.5)", "towncrier (>=18.5.0)"]
+testing = ["flaky (>=3.4.0)", "freezegun (>=0.3.11)", "pytest (>=4.0.0)", "pytest-cov (>=2.5.1)", "pytest-mock (>=1.10.0)", "pytest-randomly (>=1.0.0)", "psutil (>=5.6.1)", "pathlib2 (>=2.3.3)"]
+
+[[package]]
+name = "typed-ast"
+version = "1.5.2"
+description = "a fork of Python 2 and 3 ast modules with type comment support"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "typing-extensions"
+version = "4.1.1"
+description = "Backported and Experimental Type Hints for Python 3.6+"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "urllib3"
+version = "1.26.9"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+
+[package.extras]
+brotli = ["brotlicffi (>=0.8.0)", "brotli (>=1.0.9)", "brotlipy (>=0.6.0)"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+
+[[package]]
+name = "virtualenv"
+version = "20.13.4"
+description = "Virtual Python Environment builder"
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[package.dependencies]
+distlib = ">=0.3.1,<1"
+filelock = ">=3.2,<4"
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+platformdirs = ">=2,<3"
+six = ">=1.9.0,<2"
+
+[package.extras]
+docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=21.3)"]
+testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)", "packaging (>=20.0)"]
+
+[[package]]
+name = "wcwidth"
+version = "0.2.5"
+description = "Measures the displayed width of unicode strings in a terminal"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "zipp"
+version = "3.7.0"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
+
+[metadata]
+lock-version = "1.1"
+python-versions = ">=3.7.0,<4"
+content-hash = "ea2fe991f2f64f30aad8e55113079ad8e0ca15e25f74b05f3373fc6ce3c91d60"
+
+[metadata.files]
+alabaster = [
+    {file = "alabaster-0.7.12-py2.py3-none-any.whl", hash = "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359"},
+    {file = "alabaster-0.7.12.tar.gz", hash = "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"},
+]
+arrow = [
+    {file = "arrow-1.2.2-py3-none-any.whl", hash = "sha256:d622c46ca681b5b3e3574fcb60a04e5cc81b9625112d5fb2b44220c36c892177"},
+    {file = "arrow-1.2.2.tar.gz", hash = "sha256:05caf1fd3d9a11a1135b2b6f09887421153b94558e5ef4d090b567b47173ac2b"},
+]
+atomicwrites = [
+    {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
+    {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
+]
+attrs = [
+    {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
+    {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
+]
+babel = [
+    {file = "Babel-2.9.1-py2.py3-none-any.whl", hash = "sha256:ab49e12b91d937cd11f0b67cb259a57ab4ad2b59ac7a3b41d6c06c0ac5b0def9"},
+    {file = "Babel-2.9.1.tar.gz", hash = "sha256:bc0c176f9f6a994582230df350aa6e05ba2ebe4b3ac317eab29d9be5d2768da0"},
+]
+binaryornot = [
+    {file = "binaryornot-0.4.4-py2.py3-none-any.whl", hash = "sha256:b8b71173c917bddcd2c16070412e369c3ed7f0528926f70cac18a6c97fd563e4"},
+    {file = "binaryornot-0.4.4.tar.gz", hash = "sha256:359501dfc9d40632edc9fac890e19542db1a287bbcfa58175b66658392018061"},
+]
+black = [
+    {file = "black-22.1.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:1297c63b9e1b96a3d0da2d85d11cd9bf8664251fd69ddac068b98dc4f34f73b6"},
+    {file = "black-22.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2ff96450d3ad9ea499fc4c60e425a1439c2120cbbc1ab959ff20f7c76ec7e866"},
+    {file = "black-22.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0e21e1f1efa65a50e3960edd068b6ae6d64ad6235bd8bfea116a03b21836af71"},
+    {file = "black-22.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e2f69158a7d120fd641d1fa9a921d898e20d52e44a74a6fbbcc570a62a6bc8ab"},
+    {file = "black-22.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:228b5ae2c8e3d6227e4bde5920d2fc66cc3400fde7bcc74f480cb07ef0b570d5"},
+    {file = "black-22.1.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:b1a5ed73ab4c482208d20434f700d514f66ffe2840f63a6252ecc43a9bc77e8a"},
+    {file = "black-22.1.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:35944b7100af4a985abfcaa860b06af15590deb1f392f06c8683b4381e8eeaf0"},
+    {file = "black-22.1.0-cp36-cp36m-win_amd64.whl", hash = "sha256:7835fee5238fc0a0baf6c9268fb816b5f5cd9b8793423a75e8cd663c48d073ba"},
+    {file = "black-22.1.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:dae63f2dbf82882fa3b2a3c49c32bffe144970a573cd68d247af6560fc493ae1"},
+    {file = "black-22.1.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5fa1db02410b1924b6749c245ab38d30621564e658297484952f3d8a39fce7e8"},
+    {file = "black-22.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:c8226f50b8c34a14608b848dc23a46e5d08397d009446353dad45e04af0c8e28"},
+    {file = "black-22.1.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:2d6f331c02f0f40aa51a22e479c8209d37fcd520c77721c034517d44eecf5912"},
+    {file = "black-22.1.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:742ce9af3086e5bd07e58c8feb09dbb2b047b7f566eb5f5bc63fd455814979f3"},
+    {file = "black-22.1.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:fdb8754b453fb15fad3f72cd9cad3e16776f0964d67cf30ebcbf10327a3777a3"},
+    {file = "black-22.1.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f5660feab44c2e3cb24b2419b998846cbb01c23c7fe645fee45087efa3da2d61"},
+    {file = "black-22.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:6f2f01381f91c1efb1451998bd65a129b3ed6f64f79663a55fe0e9b74a5f81fd"},
+    {file = "black-22.1.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:efbadd9b52c060a8fc3b9658744091cb33c31f830b3f074422ed27bad2b18e8f"},
+    {file = "black-22.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:8871fcb4b447206904932b54b567923e5be802b9b19b744fdff092bd2f3118d0"},
+    {file = "black-22.1.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ccad888050f5393f0d6029deea2a33e5ae371fd182a697313bdbd835d3edaf9c"},
+    {file = "black-22.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:07e5c049442d7ca1a2fc273c79d1aecbbf1bc858f62e8184abe1ad175c4f7cc2"},
+    {file = "black-22.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:373922fc66676133ddc3e754e4509196a8c392fec3f5ca4486673e685a421321"},
+    {file = "black-22.1.0-py3-none-any.whl", hash = "sha256:3524739d76b6b3ed1132422bf9d82123cd1705086723bc3e235ca39fd21c667d"},
+    {file = "black-22.1.0.tar.gz", hash = "sha256:a7c0192d35635f6fc1174be575cb7915e92e5dd629ee79fdaf0dcfa41a80afb5"},
+]
+certifi = [
+    {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
+    {file = "certifi-2021.10.8.tar.gz", hash = "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872"},
+]
+chardet = [
+    {file = "chardet-4.0.0-py2.py3-none-any.whl", hash = "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"},
+    {file = "chardet-4.0.0.tar.gz", hash = "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa"},
+]
+charset-normalizer = [
+    {file = "charset-normalizer-2.0.12.tar.gz", hash = "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597"},
+    {file = "charset_normalizer-2.0.12-py3-none-any.whl", hash = "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"},
+]
+click = [
+    {file = "click-8.0.4-py3-none-any.whl", hash = "sha256:6a7a62563bbfabfda3a38f3023a1db4a35978c0abd76f6c9605ecd6554d6d9b1"},
+    {file = "click-8.0.4.tar.gz", hash = "sha256:8458d7b1287c5fb128c90e23381cf99dcde74beaf6c7ff6384ce84d6fe090adb"},
+]
+click-default-group = [
+    {file = "click-default-group-1.2.2.tar.gz", hash = "sha256:d9560e8e8dfa44b3562fbc9425042a0fd6d21956fcc2db0077f63f34253ab904"},
+]
+colorama = [
+    {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
+    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
+]
+cookiecutter = [
+    {file = "cookiecutter-1.7.3-py2.py3-none-any.whl", hash = "sha256:f8671531fa96ab14339d0c59b4f662a4f12a2ecacd94a0f70a3500843da588e2"},
+    {file = "cookiecutter-1.7.3.tar.gz", hash = "sha256:6b9a4d72882e243be077a7397d0f1f76fe66cf3df91f3115dbb5330e214fa457"},
+]
+coverage = [
+    {file = "coverage-6.3.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9b27d894748475fa858f9597c0ee1d4829f44683f3813633aaf94b19cb5453cf"},
+    {file = "coverage-6.3.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:37d1141ad6b2466a7b53a22e08fe76994c2d35a5b6b469590424a9953155afac"},
+    {file = "coverage-6.3.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f9987b0354b06d4df0f4d3e0ec1ae76d7ce7cbca9a2f98c25041eb79eec766f1"},
+    {file = "coverage-6.3.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:26e2deacd414fc2f97dd9f7676ee3eaecd299ca751412d89f40bc01557a6b1b4"},
+    {file = "coverage-6.3.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4dd8bafa458b5c7d061540f1ee9f18025a68e2d8471b3e858a9dad47c8d41903"},
+    {file = "coverage-6.3.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:46191097ebc381fbf89bdce207a6c107ac4ec0890d8d20f3360345ff5976155c"},
+    {file = "coverage-6.3.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:6f89d05e028d274ce4fa1a86887b071ae1755082ef94a6740238cd7a8178804f"},
+    {file = "coverage-6.3.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:58303469e9a272b4abdb9e302a780072c0633cdcc0165db7eec0f9e32f901e05"},
+    {file = "coverage-6.3.2-cp310-cp310-win32.whl", hash = "sha256:2fea046bfb455510e05be95e879f0e768d45c10c11509e20e06d8fcaa31d9e39"},
+    {file = "coverage-6.3.2-cp310-cp310-win_amd64.whl", hash = "sha256:a2a8b8bcc399edb4347a5ca8b9b87e7524c0967b335fbb08a83c8421489ddee1"},
+    {file = "coverage-6.3.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:f1555ea6d6da108e1999b2463ea1003fe03f29213e459145e70edbaf3e004aaa"},
+    {file = "coverage-6.3.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e5f4e1edcf57ce94e5475fe09e5afa3e3145081318e5fd1a43a6b4539a97e518"},
+    {file = "coverage-6.3.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7a15dc0a14008f1da3d1ebd44bdda3e357dbabdf5a0b5034d38fcde0b5c234b7"},
+    {file = "coverage-6.3.2-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21b7745788866028adeb1e0eca3bf1101109e2dc58456cb49d2d9b99a8c516e6"},
+    {file = "coverage-6.3.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:8ce257cac556cb03be4a248d92ed36904a59a4a5ff55a994e92214cde15c5bad"},
+    {file = "coverage-6.3.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:b0be84e5a6209858a1d3e8d1806c46214e867ce1b0fd32e4ea03f4bd8b2e3359"},
+    {file = "coverage-6.3.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:acf53bc2cf7282ab9b8ba346746afe703474004d9e566ad164c91a7a59f188a4"},
+    {file = "coverage-6.3.2-cp37-cp37m-win32.whl", hash = "sha256:8bdde1177f2311ee552f47ae6e5aa7750c0e3291ca6b75f71f7ffe1f1dab3dca"},
+    {file = "coverage-6.3.2-cp37-cp37m-win_amd64.whl", hash = "sha256:b31651d018b23ec463e95cf10070d0b2c548aa950a03d0b559eaa11c7e5a6fa3"},
+    {file = "coverage-6.3.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:07e6db90cd9686c767dcc593dff16c8c09f9814f5e9c51034066cad3373b914d"},
+    {file = "coverage-6.3.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:2c6dbb42f3ad25760010c45191e9757e7dce981cbfb90e42feef301d71540059"},
+    {file = "coverage-6.3.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c76aeef1b95aff3905fb2ae2d96e319caca5b76fa41d3470b19d4e4a3a313512"},
+    {file = "coverage-6.3.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8cf5cfcb1521dc3255d845d9dca3ff204b3229401994ef8d1984b32746bb45ca"},
+    {file = "coverage-6.3.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8fbbdc8d55990eac1b0919ca69eb5a988a802b854488c34b8f37f3e2025fa90d"},
+    {file = "coverage-6.3.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:ec6bc7fe73a938933d4178c9b23c4e0568e43e220aef9472c4f6044bfc6dd0f0"},
+    {file = "coverage-6.3.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:9baff2a45ae1f17c8078452e9e5962e518eab705e50a0aa8083733ea7d45f3a6"},
+    {file = "coverage-6.3.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:fd9e830e9d8d89b20ab1e5af09b32d33e1a08ef4c4e14411e559556fd788e6b2"},
+    {file = "coverage-6.3.2-cp38-cp38-win32.whl", hash = "sha256:f7331dbf301b7289013175087636bbaf5b2405e57259dd2c42fdcc9fcc47325e"},
+    {file = "coverage-6.3.2-cp38-cp38-win_amd64.whl", hash = "sha256:68353fe7cdf91f109fc7d474461b46e7f1f14e533e911a2a2cbb8b0fc8613cf1"},
+    {file = "coverage-6.3.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b78e5afb39941572209f71866aa0b206c12f0109835aa0d601e41552f9b3e620"},
+    {file = "coverage-6.3.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4e21876082ed887baed0146fe222f861b5815455ada3b33b890f4105d806128d"},
+    {file = "coverage-6.3.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:34626a7eee2a3da12af0507780bb51eb52dca0e1751fd1471d0810539cefb536"},
+    {file = "coverage-6.3.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1ebf730d2381158ecf3dfd4453fbca0613e16eaa547b4170e2450c9707665ce7"},
+    {file = "coverage-6.3.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd6fe30bd519694b356cbfcaca9bd5c1737cddd20778c6a581ae20dc8c04def2"},
+    {file = "coverage-6.3.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:96f8a1cb43ca1422f36492bebe63312d396491a9165ed3b9231e778d43a7fca4"},
+    {file = "coverage-6.3.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:dd035edafefee4d573140a76fdc785dc38829fe5a455c4bb12bac8c20cfc3d69"},
+    {file = "coverage-6.3.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5ca5aeb4344b30d0bec47481536b8ba1181d50dbe783b0e4ad03c95dc1296684"},
+    {file = "coverage-6.3.2-cp39-cp39-win32.whl", hash = "sha256:f5fa5803f47e095d7ad8443d28b01d48c0359484fec1b9d8606d0e3282084bc4"},
+    {file = "coverage-6.3.2-cp39-cp39-win_amd64.whl", hash = "sha256:9548f10d8be799551eb3a9c74bbf2b4934ddb330e08a73320123c07f95cc2d92"},
+    {file = "coverage-6.3.2-pp36.pp37.pp38-none-any.whl", hash = "sha256:18d520c6860515a771708937d2f78f63cc47ab3b80cb78e86573b0a760161faf"},
+    {file = "coverage-6.3.2.tar.gz", hash = "sha256:03e2a7826086b91ef345ff18742ee9fc47a6839ccd517061ef8fa1976e652ce9"},
+]
+distlib = [
+    {file = "distlib-0.3.4-py2.py3-none-any.whl", hash = "sha256:6564fe0a8f51e734df6333d08b8b94d4ea8ee6b99b5ed50613f731fd4089f34b"},
+    {file = "distlib-0.3.4.zip", hash = "sha256:e4b58818180336dc9c529bfb9a0b58728ffc09ad92027a3f30b7cd91e3458579"},
+]
+docutils = [
+    {file = "docutils-0.17.1-py2.py3-none-any.whl", hash = "sha256:cf316c8370a737a022b72b56874f6602acf974a37a9fba42ec2876387549fc61"},
+    {file = "docutils-0.17.1.tar.gz", hash = "sha256:686577d2e4c32380bb50cbb22f575ed742d58168cee37e99117a854bcd88f125"},
+]
+filelock = [
+    {file = "filelock-3.6.0-py3-none-any.whl", hash = "sha256:f8314284bfffbdcfa0ff3d7992b023d4c628ced6feb957351d4c48d059f56bc0"},
+    {file = "filelock-3.6.0.tar.gz", hash = "sha256:9cd540a9352e432c7246a48fe4e8712b10acb1df2ad1f30e8c070b82ae1fed85"},
+]
+flake8 = [
+    {file = "flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"},
+    {file = "flake8-3.9.2.tar.gz", hash = "sha256:07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b"},
+]
+flake8-bugbear = [
+    {file = "flake8-bugbear-22.1.11.tar.gz", hash = "sha256:4c2a4136bd4ecb8bf02d5159af302ffc067642784c9d0488b33ce4610da825ee"},
+    {file = "flake8_bugbear-22.1.11-py3-none-any.whl", hash = "sha256:ce7ae44aaaf67ef192b8a6de94a5ac617144e1675ad0654fdea556f48dc18d9b"},
+]
+flake8-comprehensions = [
+    {file = "flake8-comprehensions-3.8.0.tar.gz", hash = "sha256:8e108707637b1d13734f38e03435984f6b7854fa6b5a4e34f93e69534be8e521"},
+    {file = "flake8_comprehensions-3.8.0-py3-none-any.whl", hash = "sha256:9406314803abe1193c064544ab14fdc43c58424c0882f6ff8a581eb73fc9bb58"},
+]
+flake8-import-order = [
+    {file = "flake8-import-order-0.18.1.tar.gz", hash = "sha256:a28dc39545ea4606c1ac3c24e9d05c849c6e5444a50fb7e9cdd430fc94de6e92"},
+    {file = "flake8_import_order-0.18.1-py2.py3-none-any.whl", hash = "sha256:90a80e46886259b9c396b578d75c749801a41ee969a235e163cfe1be7afd2543"},
+]
+flake8-logging-format = [
+    {file = "flake8-logging-format-0.6.0.tar.gz", hash = "sha256:ca5f2b7fc31c3474a0aa77d227e022890f641a025f0ba664418797d979a779f8"},
+]
+flake8-mutable = [
+    {file = "flake8-mutable-1.2.0.tar.gz", hash = "sha256:ee9b77111b867d845177bbc289d87d541445ffcc6029a0c5c65865b42b18c6a6"},
+    {file = "flake8_mutable-1.2.0-py2-none-any.whl", hash = "sha256:38fd9dadcbcda6550a916197bc40ed76908119dabb37fbcca30873666c31d2d5"},
+]
+formaldict = [
+    {file = "formaldict-1.0.3-py3-none-any.whl", hash = "sha256:46356f08c89218e29b0a2d9343463361a4aa44728ffac88186bd7c2ae9d16a54"},
+    {file = "formaldict-1.0.3.tar.gz", hash = "sha256:9ee7795bf1d49906fec9a39a6b66383a5b3113800335441c94dac8ebcfa298c0"},
+]
+git-tidy = [
+    {file = "git-tidy-1.1.1.tar.gz", hash = "sha256:c434c131e67d06bce5234cedf3eaaa5f03ab7cf0e55533c9a6443863a0275b76"},
+    {file = "git_tidy-1.1.1-py3-none-any.whl", hash = "sha256:4687afa57d7a74e115405999a4d875644e0a91a1d78a19fe8dbea9aedaf66393"},
+]
+idna = [
+    {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
+    {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
+]
+imagesize = [
+    {file = "imagesize-1.3.0-py2.py3-none-any.whl", hash = "sha256:1db2f82529e53c3e929e8926a1fa9235aa82d0bd0c580359c67ec31b2fddaa8c"},
+    {file = "imagesize-1.3.0.tar.gz", hash = "sha256:cd1750d452385ca327479d45b64d9c7729ecf0b3969a58148298c77092261f9d"},
+]
+importlib-metadata = [
+    {file = "importlib_metadata-4.11.3-py3-none-any.whl", hash = "sha256:1208431ca90a8cca1a6b8af391bb53c1a2db74e5d1cef6ddced95d4b2062edc6"},
+    {file = "importlib_metadata-4.11.3.tar.gz", hash = "sha256:ea4c597ebf37142f827b8f39299579e31685c31d3a438b59f469406afd0f2539"},
+]
+iniconfig = [
+    {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
+    {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
+]
+jinja2 = [
+    {file = "Jinja2-3.0.3-py3-none-any.whl", hash = "sha256:077ce6014f7b40d03b47d1f1ca4b0fc8328a692bd284016f806ed0eaca390ad8"},
+    {file = "Jinja2-3.0.3.tar.gz", hash = "sha256:611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7"},
+]
+jinja2-time = [
+    {file = "jinja2-time-0.2.0.tar.gz", hash = "sha256:d14eaa4d315e7688daa4969f616f226614350c48730bfa1692d2caebd8c90d40"},
+    {file = "jinja2_time-0.2.0-py2.py3-none-any.whl", hash = "sha256:d3eab6605e3ec8b7a0863df09cc1d23714908fa61aa6986a845c20ba488b4efa"},
+]
+kmatch = [
+    {file = "kmatch-0.4.0-py3-none-any.whl", hash = "sha256:29306ec20e5d1550b2b9e11ea598b4403616831e798319034860b75c6d6d5d6d"},
+    {file = "kmatch-0.4.0.tar.gz", hash = "sha256:54a22fbbc03861b1adcb5e9cacac0eb78237b1f3c0f9b08b3cae8b78e0a0a650"},
+]
+markupsafe = [
+    {file = "MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:86b1f75c4e7c2ac2ccdaec2b9022845dbb81880ca318bb7a0a01fbf7813e3812"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f121a1420d4e173a5d96e47e9a0c0dcff965afdf1626d28de1460815f7c4ee7a"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a49907dd8420c5685cfa064a1335b6754b74541bbb3706c259c02ed65b644b3e"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:10c1bfff05d95783da83491be968e8fe789263689c02724e0c691933c52994f5"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b7bd98b796e2b6553da7225aeb61f447f80a1ca64f41d83612e6139ca5213aa4"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:b09bf97215625a311f669476f44b8b318b075847b49316d3e28c08e41a7a573f"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:694deca8d702d5db21ec83983ce0bb4b26a578e71fbdbd4fdcd387daa90e4d5e"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:efc1913fd2ca4f334418481c7e595c00aad186563bbc1ec76067848c7ca0a933"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-win32.whl", hash = "sha256:4a33dea2b688b3190ee12bd7cfa29d39c9ed176bda40bfa11099a3ce5d3a7ac6"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:dda30ba7e87fbbb7eab1ec9f58678558fd9a6b8b853530e176eabd064da81417"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:671cd1187ed5e62818414afe79ed29da836dde67166a9fac6d435873c44fdd02"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3799351e2336dc91ea70b034983ee71cf2f9533cdff7c14c90ea126bfd95d65a"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e72591e9ecd94d7feb70c1cbd7be7b3ebea3f548870aa91e2732960fa4d57a37"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6fbf47b5d3728c6aea2abb0589b5d30459e369baa772e0f37a0320185e87c980"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:d5ee4f386140395a2c818d149221149c54849dfcfcb9f1debfe07a8b8bd63f9a"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:bcb3ed405ed3222f9904899563d6fc492ff75cce56cba05e32eff40e6acbeaa3"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:e1c0b87e09fa55a220f058d1d49d3fb8df88fbfab58558f1198e08c1e1de842a"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-win32.whl", hash = "sha256:8dc1c72a69aa7e082593c4a203dcf94ddb74bb5c8a731e4e1eb68d031e8498ff"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:97a68e6ada378df82bc9f16b800ab77cbf4b2fada0081794318520138c088e4a"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:e8c843bbcda3a2f1e3c2ab25913c80a3c5376cd00c6e8c4a86a89a28c8dc5452"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0212a68688482dc52b2d45013df70d169f542b7394fc744c02a57374a4207003"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8e576a51ad59e4bfaac456023a78f6b5e6e7651dcd383bcc3e18d06f9b55d6d1"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b9fe39a2ccc108a4accc2676e77da025ce383c108593d65cc909add5c3bd601"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:96e37a3dc86e80bf81758c152fe66dbf60ed5eca3d26305edf01892257049925"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:6d0072fea50feec76a4c418096652f2c3238eaa014b2f94aeb1d56a66b41403f"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:089cf3dbf0cd6c100f02945abeb18484bd1ee57a079aefd52cffd17fba910b88"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:6a074d34ee7a5ce3effbc526b7083ec9731bb3cbf921bbe1d3005d4d2bdb3a63"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-win32.whl", hash = "sha256:421be9fbf0ffe9ffd7a378aafebbf6f4602d564d34be190fc19a193232fd12b1"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:fc7b548b17d238737688817ab67deebb30e8073c95749d55538ed473130ec0c7"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:e04e26803c9c3851c931eac40c695602c6295b8d432cbe78609649ad9bd2da8a"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b87db4360013327109564f0e591bd2a3b318547bcef31b468a92ee504d07ae4f"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:99a2a507ed3ac881b975a2976d59f38c19386d128e7a9a18b7df6fff1fd4c1d6"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:56442863ed2b06d19c37f94d999035e15ee982988920e12a5b4ba29b62ad1f77"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3ce11ee3f23f79dbd06fb3d63e2f6af7b12db1d46932fe7bd8afa259a5996603"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:33b74d289bd2f5e527beadcaa3f401e0df0a89927c1559c8566c066fa4248ab7"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:43093fb83d8343aac0b1baa75516da6092f58f41200907ef92448ecab8825135"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:8e3dcf21f367459434c18e71b2a9532d96547aef8a871872a5bd69a715c15f96"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-win32.whl", hash = "sha256:d4306c36ca495956b6d568d276ac11fdd9c30a36f1b6eb928070dc5360b22e1c"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:46d00d6cfecdde84d40e572d63735ef81423ad31184100411e6e3388d405e247"},
+    {file = "MarkupSafe-2.1.1.tar.gz", hash = "sha256:7f91197cc9e48f989d12e4e6fbc46495c446636dfc81b9ccf50bb0ec74b91d4b"},
+]
+mccabe = [
+    {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
+    {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
+]
+mypy-extensions = [
+    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
+    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+]
+packaging = [
+    {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
+    {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
+]
+pathspec = [
+    {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
+    {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
+]
+platformdirs = [
+    {file = "platformdirs-2.5.1-py3-none-any.whl", hash = "sha256:bcae7cab893c2d310a711b70b24efb93334febe65f8de776ee320b517471e227"},
+    {file = "platformdirs-2.5.1.tar.gz", hash = "sha256:7535e70dfa32e84d4b34996ea99c5e432fa29a708d0f4e394bbcb2a8faa4f16d"},
+]
+pluggy = [
+    {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
+    {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
+]
+poyo = [
+    {file = "poyo-0.5.0-py2.py3-none-any.whl", hash = "sha256:3e2ca8e33fdc3c411cd101ca395668395dd5dc7ac775b8e809e3def9f9fe041a"},
+    {file = "poyo-0.5.0.tar.gz", hash = "sha256:e26956aa780c45f011ca9886f044590e2d8fd8b61db7b1c1cf4e0869f48ed4dd"},
+]
+prompt-toolkit = [
+    {file = "prompt_toolkit-3.0.28-py3-none-any.whl", hash = "sha256:30129d870dcb0b3b6a53efdc9d0a83ea96162ffd28ffe077e94215b233dc670c"},
+    {file = "prompt_toolkit-3.0.28.tar.gz", hash = "sha256:9f1cd16b1e86c2968f2519d7fb31dd9d669916f515612c269d14e9ed52b51650"},
+]
+py = [
+    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
+    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
+]
+pycodestyle = [
+    {file = "pycodestyle-2.7.0-py2.py3-none-any.whl", hash = "sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068"},
+    {file = "pycodestyle-2.7.0.tar.gz", hash = "sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef"},
+]
+pyflakes = [
+    {file = "pyflakes-2.3.1-py2.py3-none-any.whl", hash = "sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3"},
+    {file = "pyflakes-2.3.1.tar.gz", hash = "sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db"},
+]
+pygments = [
+    {file = "Pygments-2.11.2-py3-none-any.whl", hash = "sha256:44238f1b60a76d78fc8ca0528ee429702aae011c265fe6a8dd8b63049ae41c65"},
+    {file = "Pygments-2.11.2.tar.gz", hash = "sha256:4e426f72023d88d03b2fa258de560726ce890ff3b630f88c21cbb8b2503b8c6a"},
+]
+pyparsing = [
+    {file = "pyparsing-3.0.7-py3-none-any.whl", hash = "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"},
+    {file = "pyparsing-3.0.7.tar.gz", hash = "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea"},
+]
+pytest = [
+    {file = "pytest-6.2.5-py3-none-any.whl", hash = "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"},
+    {file = "pytest-6.2.5.tar.gz", hash = "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89"},
+]
+pytest-cov = [
+    {file = "pytest-cov-3.0.0.tar.gz", hash = "sha256:e7f0f5b1617d2210a2cabc266dfe2f4c75a8d32fb89eafb7ad9d06f6d076d470"},
+    {file = "pytest_cov-3.0.0-py3-none-any.whl", hash = "sha256:578d5d15ac4a25e5f961c938b85a05b09fdaae9deef3bb6de9a6e766622ca7a6"},
+]
+pytest-mock = [
+    {file = "pytest-mock-3.7.0.tar.gz", hash = "sha256:5112bd92cc9f186ee96e1a92efc84969ea494939c3aead39c50f421c4cc69534"},
+    {file = "pytest_mock-3.7.0-py3-none-any.whl", hash = "sha256:6cff27cec936bf81dc5ee87f07132b807bcda51106b5ec4b90a04331cba76231"},
+]
+pytest-responses = [
+    {file = "pytest_responses-0.5.0-py2.py3-none-any.whl", hash = "sha256:6fffd7412294c8a01ccfec05ae51910db76aeb0df877c5fac16c64991cb465e6"},
+]
+python-dateutil = [
+    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
+    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+]
+python-slugify = [
+    {file = "python-slugify-6.1.1.tar.gz", hash = "sha256:00003397f4e31414e922ce567b3a4da28cf1436a53d332c9aeeb51c7d8c469fd"},
+    {file = "python_slugify-6.1.1-py2.py3-none-any.whl", hash = "sha256:8c0016b2d74503eb64761821612d58fcfc729493634b1eb0575d8f5b4aa1fbcf"},
+]
+pytz = [
+    {file = "pytz-2022.1-py2.py3-none-any.whl", hash = "sha256:e68985985296d9a66a881eb3193b0906246245294a881e7c8afe623866ac6a5c"},
+    {file = "pytz-2022.1.tar.gz", hash = "sha256:1e760e2fe6a8163bc0b3d9a19c4f84342afa0a2affebfaa84b01b978a02ecaa7"},
+]
+pyyaml = [
+    {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
+    {file = "PyYAML-6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a80a78046a72361de73f8f395f1f1e49f956c6be882eed58505a15f3e430962b"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"},
+    {file = "PyYAML-6.0-cp310-cp310-win32.whl", hash = "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513"},
+    {file = "PyYAML-6.0-cp310-cp310-win_amd64.whl", hash = "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a"},
+    {file = "PyYAML-6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98c4d36e99714e55cfbaaee6dd5badbc9a1ec339ebfc3b1f52e293aee6bb71a4"},
+    {file = "PyYAML-6.0-cp36-cp36m-win32.whl", hash = "sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293"},
+    {file = "PyYAML-6.0-cp36-cp36m-win_amd64.whl", hash = "sha256:07751360502caac1c067a8132d150cf3d61339af5691fe9e87803040dbc5db57"},
+    {file = "PyYAML-6.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:819b3830a1543db06c4d4b865e70ded25be52a2e0631ccd2f6a47a2822f2fd7c"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:473f9edb243cb1935ab5a084eb238d842fb8f404ed2193a915d1784b5a6b5fc0"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ce82d761c532fe4ec3f87fc45688bdd3a4c1dc5e0b4a19814b9009a29baefd4"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:231710d57adfd809ef5d34183b8ed1eeae3f76459c18fb4a0b373ad56bedcdd9"},
+    {file = "PyYAML-6.0-cp37-cp37m-win32.whl", hash = "sha256:c5687b8d43cf58545ade1fe3e055f70eac7a5a1a0bf42824308d868289a95737"},
+    {file = "PyYAML-6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:d15a181d1ecd0d4270dc32edb46f7cb7733c7c508857278d3d378d14d606db2d"},
+    {file = "PyYAML-6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0b4624f379dab24d3725ffde76559cff63d9ec94e1736b556dacdfebe5ab6d4b"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:213c60cd50106436cc818accf5baa1aba61c0189ff610f64f4a3e8c6726218ba"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9fa600030013c4de8165339db93d182b9431076eb98eb40ee068700c9c813e34"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:277a0ef2981ca40581a47093e9e2d13b3f1fbbeffae064c1d21bfceba2030287"},
+    {file = "PyYAML-6.0-cp38-cp38-win32.whl", hash = "sha256:d4eccecf9adf6fbcc6861a38015c2a64f38b9d94838ac1810a9023a0609e1b78"},
+    {file = "PyYAML-6.0-cp38-cp38-win_amd64.whl", hash = "sha256:1e4747bc279b4f613a09eb64bba2ba602d8a6664c6ce6396a4d0cd413a50ce07"},
+    {file = "PyYAML-6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:055d937d65826939cb044fc8c9b08889e8c743fdc6a32b33e2390f66013e449b"},
+    {file = "PyYAML-6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d67d839ede4ed1b28a4e8909735fc992a923cdb84e618544973d7dfc71540803"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cba8c411ef271aa037d7357a2bc8f9ee8b58b9965831d9e51baf703280dc73d3"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:40527857252b61eacd1d9af500c3337ba8deb8fc298940291486c465c8b46ec0"},
+    {file = "PyYAML-6.0-cp39-cp39-win32.whl", hash = "sha256:b5b9eccad747aabaaffbc6064800670f0c297e52c12754eb1d976c57e4f74dcb"},
+    {file = "PyYAML-6.0-cp39-cp39-win_amd64.whl", hash = "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c"},
+    {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
+]
+requests = [
+    {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},
+    {file = "requests-2.27.1.tar.gz", hash = "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"},
+]
+responses = [
+    {file = "responses-0.20.0-py3-none-any.whl", hash = "sha256:18831bc2d72443b67664d98038374a6fa1f27eaaff4dd9a7d7613723416fea3c"},
+    {file = "responses-0.20.0.tar.gz", hash = "sha256:644905bc4fb8a18fa37e3882b2ac05e610fe8c2f967d327eed669e314d94a541"},
+]
+six = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+snowballstemmer = [
+    {file = "snowballstemmer-2.2.0-py2.py3-none-any.whl", hash = "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"},
+    {file = "snowballstemmer-2.2.0.tar.gz", hash = "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1"},
+]
+sphinx = [
+    {file = "Sphinx-4.4.0-py3-none-any.whl", hash = "sha256:5da895959511473857b6d0200f56865ed62c31e8f82dd338063b84ec022701fe"},
+    {file = "Sphinx-4.4.0.tar.gz", hash = "sha256:6caad9786055cb1fa22b4a365c1775816b876f91966481765d7d50e9f0dd35cc"},
+]
+sphinx-click = [
+    {file = "sphinx-click-3.0.0.tar.gz", hash = "sha256:5f0d10a992eae1aa869b22720281eb3f2d0d8fa30364e75db31db52539c70f9e"},
+    {file = "sphinx_click-3.0.0-py3-none-any.whl", hash = "sha256:5ae8e558ffe3ee976410f2bbd9213d2c1127bd22df1a47099bf179e775f24591"},
+]
+sphinx-rtd-theme = [
+    {file = "sphinx_rtd_theme-1.0.0-py2.py3-none-any.whl", hash = "sha256:4d35a56f4508cfee4c4fb604373ede6feae2a306731d533f409ef5c3496fdbd8"},
+    {file = "sphinx_rtd_theme-1.0.0.tar.gz", hash = "sha256:eec6d497e4c2195fa0e8b2016b337532b8a699a68bcb22a512870e16925c6a5c"},
+]
+sphinxcontrib-applehelp = [
+    {file = "sphinxcontrib-applehelp-1.0.2.tar.gz", hash = "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"},
+    {file = "sphinxcontrib_applehelp-1.0.2-py2.py3-none-any.whl", hash = "sha256:806111e5e962be97c29ec4c1e7fe277bfd19e9652fb1a4392105b43e01af885a"},
+]
+sphinxcontrib-devhelp = [
+    {file = "sphinxcontrib-devhelp-1.0.2.tar.gz", hash = "sha256:ff7f1afa7b9642e7060379360a67e9c41e8f3121f2ce9164266f61b9f4b338e4"},
+    {file = "sphinxcontrib_devhelp-1.0.2-py2.py3-none-any.whl", hash = "sha256:8165223f9a335cc1af7ffe1ed31d2871f325254c0423bc0c4c7cd1c1e4734a2e"},
+]
+sphinxcontrib-htmlhelp = [
+    {file = "sphinxcontrib-htmlhelp-2.0.0.tar.gz", hash = "sha256:f5f8bb2d0d629f398bf47d0d69c07bc13b65f75a81ad9e2f71a63d4b7a2f6db2"},
+    {file = "sphinxcontrib_htmlhelp-2.0.0-py2.py3-none-any.whl", hash = "sha256:d412243dfb797ae3ec2b59eca0e52dac12e75a241bf0e4eb861e450d06c6ed07"},
+]
+sphinxcontrib-jsmath = [
+    {file = "sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8"},
+    {file = "sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl", hash = "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178"},
+]
+sphinxcontrib-qthelp = [
+    {file = "sphinxcontrib-qthelp-1.0.3.tar.gz", hash = "sha256:4c33767ee058b70dba89a6fc5c1892c0d57a54be67ddd3e7875a18d14cba5a72"},
+    {file = "sphinxcontrib_qthelp-1.0.3-py2.py3-none-any.whl", hash = "sha256:bd9fc24bcb748a8d51fd4ecaade681350aa63009a347a8c14e637895444dfab6"},
+]
+sphinxcontrib-serializinghtml = [
+    {file = "sphinxcontrib-serializinghtml-1.1.5.tar.gz", hash = "sha256:aa5f6de5dfdf809ef505c4895e51ef5c9eac17d0f287933eb49ec495280b6952"},
+    {file = "sphinxcontrib_serializinghtml-1.1.5-py2.py3-none-any.whl", hash = "sha256:352a9a00ae864471d3a7ead8d7d79f5fc0b57e8b3f95e9867eb9eb28999b92fd"},
+]
+temple = [
+    {file = "temple-1.4.7-py3-none-any.whl", hash = "sha256:76adc4b0fb8c681689f5291a5f02f2a2da399cbd976a19358360771af1a01c78"},
+    {file = "temple-1.4.7.tar.gz", hash = "sha256:24c6b7003b56312e74f5d583025a7cb5ecb703d167025e26b3ba163fb4b7bc85"},
+]
+text-unidecode = [
+    {file = "text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93"},
+    {file = "text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8"},
+]
+toml = [
+    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
+    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
+tomli = [
+    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
+    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+]
+tox = [
+    {file = "tox-3.24.5-py2.py3-none-any.whl", hash = "sha256:be3362472a33094bce26727f5f771ca0facf6dafa217f65875314e9a6600c95c"},
+    {file = "tox-3.24.5.tar.gz", hash = "sha256:67e0e32c90e278251fea45b696d0fef3879089ccbe979b0c556d35d5a70e2993"},
+]
+typed-ast = [
+    {file = "typed_ast-1.5.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:183b183b7771a508395d2cbffd6db67d6ad52958a5fdc99f450d954003900266"},
+    {file = "typed_ast-1.5.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:676d051b1da67a852c0447621fdd11c4e104827417bf216092ec3e286f7da596"},
+    {file = "typed_ast-1.5.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bc2542e83ac8399752bc16e0b35e038bdb659ba237f4222616b4e83fb9654985"},
+    {file = "typed_ast-1.5.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:74cac86cc586db8dfda0ce65d8bcd2bf17b58668dfcc3652762f3ef0e6677e76"},
+    {file = "typed_ast-1.5.2-cp310-cp310-win_amd64.whl", hash = "sha256:18fe320f354d6f9ad3147859b6e16649a0781425268c4dde596093177660e71a"},
+    {file = "typed_ast-1.5.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:31d8c6b2df19a777bc8826770b872a45a1f30cfefcfd729491baa5237faae837"},
+    {file = "typed_ast-1.5.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:963a0ccc9a4188524e6e6d39b12c9ca24cc2d45a71cfdd04a26d883c922b4b78"},
+    {file = "typed_ast-1.5.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:0eb77764ea470f14fcbb89d51bc6bbf5e7623446ac4ed06cbd9ca9495b62e36e"},
+    {file = "typed_ast-1.5.2-cp36-cp36m-win_amd64.whl", hash = "sha256:294a6903a4d087db805a7656989f613371915fc45c8cc0ddc5c5a0a8ad9bea4d"},
+    {file = "typed_ast-1.5.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:26a432dc219c6b6f38be20a958cbe1abffcc5492821d7e27f08606ef99e0dffd"},
+    {file = "typed_ast-1.5.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c7407cfcad702f0b6c0e0f3e7ab876cd1d2c13b14ce770e412c0c4b9728a0f88"},
+    {file = "typed_ast-1.5.2-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f30ddd110634c2d7534b2d4e0e22967e88366b0d356b24de87419cc4410c41b7"},
+    {file = "typed_ast-1.5.2-cp37-cp37m-win_amd64.whl", hash = "sha256:8c08d6625bb258179b6e512f55ad20f9dfef019bbfbe3095247401e053a3ea30"},
+    {file = "typed_ast-1.5.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:90904d889ab8e81a956f2c0935a523cc4e077c7847a836abee832f868d5c26a4"},
+    {file = "typed_ast-1.5.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:bbebc31bf11762b63bf61aaae232becb41c5bf6b3461b80a4df7e791fabb3aca"},
+    {file = "typed_ast-1.5.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c29dd9a3a9d259c9fa19d19738d021632d673f6ed9b35a739f48e5f807f264fb"},
+    {file = "typed_ast-1.5.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:58ae097a325e9bb7a684572d20eb3e1809802c5c9ec7108e85da1eb6c1a3331b"},
+    {file = "typed_ast-1.5.2-cp38-cp38-win_amd64.whl", hash = "sha256:da0a98d458010bf4fe535f2d1e367a2e2060e105978873c04c04212fb20543f7"},
+    {file = "typed_ast-1.5.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:33b4a19ddc9fc551ebabca9765d54d04600c4a50eda13893dadf67ed81d9a098"},
+    {file = "typed_ast-1.5.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:1098df9a0592dd4c8c0ccfc2e98931278a6c6c53cb3a3e2cf7e9ee3b06153344"},
+    {file = "typed_ast-1.5.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42c47c3b43fe3a39ddf8de1d40dbbfca60ac8530a36c9b198ea5b9efac75c09e"},
+    {file = "typed_ast-1.5.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f290617f74a610849bd8f5514e34ae3d09eafd521dceaa6cf68b3f4414266d4e"},
+    {file = "typed_ast-1.5.2-cp39-cp39-win_amd64.whl", hash = "sha256:df05aa5b241e2e8045f5f4367a9f6187b09c4cdf8578bb219861c4e27c443db5"},
+    {file = "typed_ast-1.5.2.tar.gz", hash = "sha256:525a2d4088e70a9f75b08b3f87a51acc9cde640e19cc523c7e41aa355564ae27"},
+]
+typing-extensions = [
+    {file = "typing_extensions-4.1.1-py3-none-any.whl", hash = "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"},
+    {file = "typing_extensions-4.1.1.tar.gz", hash = "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42"},
+]
+urllib3 = [
+    {file = "urllib3-1.26.9-py2.py3-none-any.whl", hash = "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14"},
+    {file = "urllib3-1.26.9.tar.gz", hash = "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"},
+]
+virtualenv = [
+    {file = "virtualenv-20.13.4-py2.py3-none-any.whl", hash = "sha256:c3e01300fb8495bc00ed70741f5271fc95fed067eb7106297be73d30879af60c"},
+    {file = "virtualenv-20.13.4.tar.gz", hash = "sha256:ce8901d3bbf3b90393498187f2d56797a8a452fb2d0d7efc6fd837554d6f679c"},
+]
+wcwidth = [
+    {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},
+    {file = "wcwidth-0.2.5.tar.gz", hash = "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"},
+]
+zipp = [
+    {file = "zipp-3.7.0-py3-none-any.whl", hash = "sha256:b47250dd24f92b7dd6a0a8fc5244da14608f3ca90a5efcd37a3b1642fac9a375"},
+    {file = "zipp-3.7.0.tar.gz", hash = "sha256:9f50f446828eb9d45b267433fd3e9da8d801f614129124863f9c51ebceafb87d"},
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,10 @@ fail_under = 100
 [tool.poetry]
 name = "detail"
 packages = [
-  { include = "detail" }
+  { include = "detail" },
+]
+exclude = [
+  "detail/tests"
 ]
 version = "0.0.0"
 description = "Build automations off of structured notes in your project"
@@ -48,6 +51,14 @@ documentation = "https://detail.readthedocs.io"
 
 [tool.poetry.dependencies]
 python = ">=3.7.0,<4"
+importlib_metadata = { version = ">=4", python = "~3.7" }
+click = ">=7.0"
+click-default-group = ">=1.2.2"
+formaldict = ">=0.2.0"
+jinja2 = ">=2.10.3"
+python-dateutil = ">=2.8.1"
+pyyaml = ">=5.1.2"
+requests = ">=2.22.0"
 
 [tool.poetry.dev-dependencies]
 black = "22.1.0"
@@ -60,10 +71,16 @@ flake8-mutable = "1.2.0"
 git-tidy = "1.1.1"
 pytest = "6.2.5"
 pytest-cov = "3.0.0"
+pytest-mock = "3.7.0"
+pytest-responses = "0.5.0"
 Sphinx = "4.4.0"
+sphinx-click = "3.0.0"
 sphinx-rtd-theme = "1.0.0"
 temple = "*"
 tox = "3.24.5"
+
+[tool.poetry.scripts]
+detail = 'detail.cli:main'
 
 [tool.pytest.ini_options]
 xfail_strict = true

--- a/tox.ini
+++ b/tox.ini
@@ -4,11 +4,13 @@ envlist = clean,py{37,38,39,310},report
 
 [testenv]
 whitelist_externals =
-    poetry
+    bash
     pytest
+    pip
 skip_install = true
 commands =
-    poetry install -v
+    bash -c 'poetry export --dev --without-hashes -f requirements.txt | pip install --no-deps -r /dev/stdin'
+    pip install -e . --no-deps
     pytest --cov --cov-fail-under=0 --cov-append --cov-config pyproject.toml detail/
 
 [testenv:report]


### PR DESCRIPTION
V1 of ``detail`` includes the ability to make structured notes in a repository,
allowing a user several options for automations on those notes.

This V1 release was inspired by ``git-tidy`` and mimics the interface of it.
The main difference here is that ``detail`` is storing structured notes in
files that are part of the project instead of the commit log.

Along with the core ``detail`` CLI for creating/updating notes, the CLI
contains a ``lint`` subcommand for linting notes against a git range and
a ``log`` subcommand for logging notes against a git range.

Type: feature

@tomage trying again, but with a new name since the other was taken on pypi