### PR TITLE
Change linting behavior, passing if no commits exist

### DIFF
--- a/detail/cli.py
+++ b/detail/cli.py
@@ -55,17 +55,17 @@ def lint(ctx, range):
     range = ' '.join(range)
     is_valid, notes = core.lint(range)
 
-    if not notes:
-        click.echo('No notes were found. Run "detail" to create one', err=True)
-        ctx.exit(1)
-
     if not is_valid:
-        failures = notes.filter('is_valid', False)
-        err_msg = f'{len(failures)} out of {len(notes)} notes have failed linting:'
-        click.echo(click.style(err_msg, fg='red'), err=True)
+        if not notes:
+            click.echo('No notes were found. Run "detail" to create one', err=True)
+        else:
+            failures = notes.filter('is_valid', False)
+            err_msg = f'{len(failures)} out of {len(notes)} notes have failed linting:'
+            click.echo(click.style(err_msg, fg='red'), err=True)
 
-        for failure in failures:
-            click.echo(f'{failure.path}: {failure.validation_errors}', err=True)
+            for failure in failures:
+                click.echo(f'{failure.path}: {failure.validation_errors}', err=True)
+
         ctx.exit(1)
 
 

--- a/detail/tests/test_integration.py
+++ b/detail/tests/test_integration.py
@@ -344,9 +344,20 @@ def test_detail_update(mocker):
 @pytest.mark.usefixtures('detail_repo')
 def test_lint():
     """Tests core.lint()"""
-    passed, commits = core.lint()
+    passed, notes = core.lint()
     assert not passed
-    assert len(commits) == 5
+    assert len(notes) == 5
+    assert len(notes.commits) == 6
+
+    passed, notes = core.lint(range='HEAD..')
+    assert passed
+    assert len(notes) == 0
+    assert len(notes.commits) == 0
+
+    passed, notes = core.lint(range='HEAD~1..')
+    assert not passed
+    assert len(notes) == 0
+    assert len(notes.commits) == 1
 
 
 @pytest.mark.parametrize('output', [None, 'output_file', io.StringIO(), ':github/pr'])

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -101,6 +101,14 @@ to validate. Normally this is done against the branch over which a pull
 request will be submitted. For example, ``detail lint origin/develop..``
 will lint all of the commits on your branch since ``origin/develop``.
 
+Linting will pass if any of the following are true:
+
+1. There are no commits in the range. For example, running ``detail lint main..``
+   while on the ``main`` branch will result in linting passing since there are
+   no commits.
+2. There is at least one commit, at least one note, and all notes present
+   in the commit range adhere to the ``detail`` schema.
+
 ``detail`` comes built in with Github support. In order to lint against all
 of the commits against the base branch of an open pull request, run
 ``detail lint :github/pr``. The special ":github/pr" range tells


### PR DESCRIPTION
If no commits exist during ``detail lint``, linting passes
since there is nothing to check. If commits exist and there are no
notes, linting fails like before.

Type: feature